### PR TITLE
refactor(server): unify db access with promise-first wrapper

### DIFF
--- a/server/api/admin.js
+++ b/server/api/admin.js
@@ -1,137 +1,79 @@
-const SqlString = require('mysql/lib/protocol/SqlString');
-const db = require('../db/index');
+const db = require('../db');
+const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
 
-exports.getUserInfoList = (req, res) => {
-  if (req.session.gid < 3) return res.status(403).end('403 Forbidden');
-  let pageId = req.body.pageId, filter = req.body.filter, pageSize = 20;
-  if (!pageId) pageId = 1;
-  let sql = "SELECT uid,name,email,gid,inUse FROM userInfo WHERE uid > 0 ";
+exports.getUserInfoList = [
+  requireRole(3),
+  handler(async (req, res) => {
+    const { offset, limit } = paginate(req);
+    const filter = req.body.filter || {};
 
-  pageId = SqlString.escape(pageId);
+    const cond = [
+      ['uid=?', filter.uid],
+      ['name LIKE ?', filter.name ? `%${filter.name}%` : null],
+      ['email LIKE ?', filter.email ? `%${filter.email}%` : null],
+      ['gid=?', filter.gid],
+      // 前端 inUse=1 表示封禁(=0)，inUse=2 表示正常(=1)
+      ['inUse=?', filter.inUse ? 2 - filter.inUse : null],
+    ];
+    const { where, params } = buildWhere(cond, 'uid > 0');
 
-  if (filter.uid) {
-    filter.uid = SqlString.escape(filter.uid);
-    sql += `AND uid=${filter.uid} `;
-  }
-  if (filter.name) {
-    filter.name = SqlString.escape('%' + filter.name + '%');
-    sql += `AND name like ${filter.name} `;
-  }
-  if (filter.email) {
-    filter.email = SqlString.escape('%' + filter.email + '%');
-    sql += `AND email like ${filter.email} `;
-  }
-  if (filter.gid) {
-    filter.gid = SqlString.escape(filter.gid);
-    sql += `AND gid=${filter.gid} `;
-  }
-  if (filter.inUse) {
-    filter.inUse = SqlString.escape(filter.inUse);
-    sql += `AND inUse=${2 - filter.inUse} `; // fit for front-end
-  }
-  sql += " LIMIT " + (pageId - 1) * pageSize + "," + pageSize;
+    const list = await db.query(
+      `SELECT uid,name,email,gid,inUse FROM userInfo${where} LIMIT ?,?`,
+      [...params, offset, limit]
+    );
+    const cnt = await db.one(`SELECT COUNT(*) as total FROM userInfo${where}`, params);
+    return ok(res, { total: cnt.total, userList: list });
+  }),
+];
 
-  db.query(sql, (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    let list = data, csql = "SELECT COUNT(*) as total FROM userInfo WHERE uid > 0 ";
-    if (filter.uid)
-      csql += `AND uid=${filter.uid} `;
-    if (filter.name)
-      csql += `AND name like ${filter.name} `;
-    if (filter.email)
-      csql += `AND email like ${filter.email} `;
-    if (filter.gid)
-      csql += `AND gid=${filter.gid} `;
-    if (filter.inUse)
-      csql += `AND inUse=${2 - filter.inUse} `; // fit for front-end
-    db.query(csql, (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      return res.status(200).send({
-        total: data[0].total,
-        userList: list
-      });
-    });
-  });
-}
+exports.setBlock = [
+  requireRole(3),
+  handler(async (req, res) => {
+    const { uid, status } = req.body;
+    if (uid == null || status == null) return fail(res, '请确认信息完善');
+    const r = await db.query('UPDATE userInfo SET inUse=? WHERE uid=?', [status, uid]);
+    if (!r.affectedRows) return fail(res, 'failed');
+    return ok(res);
+  }),
+];
 
-exports.setBlock = (req, res) => {
-  if (req.session.gid < 3) return res.status(403).end('403 Forbidden');
-  const uid = req.body.uid, status = req.body.status;
-  if (uid === null || status === null) {
-    return res.status(202).send({
-      message: '请确认信息完善'
-    });
-  }
-  let sql = "UPDATE userInfo SET inUse=? WHERE uid=?";
-  db.query(sql, [status, uid], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (data.affectedRows > 0) {
-      return res.status(200).send({
-        message: 'sueecss'
-      });
-    } else {
-      return res.status(202).send({
-        message: 'failed'
-      });
-    }
-  })
-}
+exports.updateUserInfo = [
+  requireRole(3),
+  handler(async (req, res) => {
+    const info = req.body.info || {};
+    const { uid, name, email, gid } = info;
+    if (!uid || !name || !gid) return fail(res, '请确认信息完善');
+    const r = await db.query(
+      'UPDATE userInfo SET name=?,email=?,gid=? WHERE uid=?',
+      [name, email, gid, uid]
+    );
+    if (!r.affectedRows) return fail(res, 'failed');
+    return ok(res);
+  }),
+];
 
-exports.updateUserInfo = (req, res) => {
-  if (req.session.gid < 3) return res.status(403).end('403 Forbidden');
-  const newInfo = req.body.info;
-  const uid = newInfo.uid, name = newInfo.name, email = newInfo.email, gid = newInfo.gid;
-  if (!uid || !name || !gid) {
-    return res.status(202).send({
-      message: '请确认信息完善'
-    });
-  }
-  db.query("UPDATE userInfo SET name=?,email=?,gid=? WHERE uid=?", [name, email, gid, uid], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (data.affectedRows > 0) {
-      return res.status(200).send({
-        message: 'sueecss'
-      });
-    } else {
-      return res.status(202).send({
-        message: 'failed'
-      });
-    }
-  })
-}
+exports.addAnnouncement = [
+  requireRole(3),
+  handler(async (req, res) => {
+    const r = await db.query(
+      'INSERT INTO announcement(title,description,weight,time) VALUES (?,?,?,?)',
+      ['请输入公告标题', '请输入公告描述', 10, new Date()]
+    );
+    if (!r.affectedRows) return fail(res, 'error');
+    return ok(res, { aid: r.insertId });
+  }),
+];
 
-exports.addAnnouncement = (req, res) => {
-  if (req.session.gid < 3) return res.status(403).end('403 Forbidden');
-  db.query('INSERT INTO announcement(title,description,weight,time) VALUES (?,?,?,?)', ["请输入公告标题", "请输入公告描述", 10, new Date()], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    if (data.affectedRows > 0) {
-      return res.status(200).send({
-        aid: data.insertId
-      })
-    } else {
-      return res.status(202).send({
-        message: 'error',
-      })
-    }
-  });
-}
-
-exports.updateAnnouncement = (req, res) => {
-  if (req.session.gid < 3) return res.status(403).end('403 Forbidden');
-  const info = req.body.info;
-  const aid = info.aid, title = info.title, description = info.description, weight = info.weight;
-  db.query("UPDATE announcement SET title=?,description=?,weight=? WHERE aid=?", [title, description, weight, aid], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (data.affectedRows > 0) {
-      return res.status(200).send({
-        message: 'sueecss'
-      });
-    } else {
-      return res.status(202).send({
-        message: 'failed'
-      });
-    }
-  })
-}
+exports.updateAnnouncement = [
+  requireRole(3),
+  handler(async (req, res) => {
+    const info = req.body.info || {};
+    const { aid, title, description, weight } = info;
+    const r = await db.query(
+      'UPDATE announcement SET title=?,description=?,weight=? WHERE aid=?',
+      [title, description, weight, aid]
+    );
+    if (!r.affectedRows) return fail(res, 'failed');
+    return ok(res);
+  }),
+];

--- a/server/api/common.js
+++ b/server/api/common.js
@@ -1,148 +1,110 @@
-const db = require('../db/index');
-const { briefFormat, Format } = require('../static');
-const SqlString = require('mysql/lib/protocol/SqlString');
 const { randomInt } = require('crypto');
+const db = require('../db');
+const { handler, fail, ok, paginate, buildWhere } = require('../db/util');
+const { briefFormat, Format } = require('../static');
 
 const getMark = () => {
   const time = Date.now().toString(36);
   const str = Math.random().toString(36).slice(2, 7);
   return `${time}-${str}`;
-}
+};
 
-exports.getAnnouncementList = (req, res) => {
-  let sql = "SELECT aid,time,title FROM announcement ORDER BY weight desc LIMIT 5";
-  db.query(sql, (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    for (let i = 0; i < data.length; i++) data[i].time = briefFormat(data[i].time);
-    return res.status(200).send({
-      data: data
-    });
-  });
-}
+exports.getAnnouncementList = handler(async (req, res) => {
+  const rows = await db.query('SELECT aid,time,title FROM announcement ORDER BY weight DESC LIMIT 5');
+  for (const r of rows) r.time = briefFormat(r.time);
+  return ok(res, { data: rows });
+});
 
-exports.getAnnouncementInfo = (req, res) => {
-  const aid = req.body.aid;
-  let sql = "SELECT * FROM announcement WHERE aid=?";
-  db.query(sql, [aid], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({
-      message: 'error'
-    });
-    else {
-      data[0].time = briefFormat(data[0].time);
-      return res.status(200).send({
-        data: data[0]
-      });
-    }
-  });
-}
+exports.getAnnouncementInfo = handler(async (req, res) => {
+  const row = await db.one('SELECT * FROM announcement WHERE aid=?', [req.body.aid]);
+  if (!row) return fail(res, 'error');
+  row.time = briefFormat(row.time);
+  return ok(res, { data: row });
+});
 
-exports.getPaste = (req, res) => {
-  db.query('SELECT title,mark,content,uid,time,isPublic FROM pastes WHERE mark=?', [req.body.mark], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '未找到' });
-    if (req.session.gid < 3 && (!data[0].isPublic && data[0].uid !== req.session.uid))
-      return res.status(202).send({ message: '无权限查看' });
-    data[0].time = Format(data[0].time);
-    db.query('SELECT name FROM userInfo WHERE uid=?', [data[0].uid], (err2, data2) => {
-      if (err) return res.status(202).send({ message: err2 });
-      data[0].paster = data2[0].name;
-      return res.status(200).send({
-        data: data[0]
-      });
-    })
-  });
-}
+exports.getPaste = handler(async (req, res) => {
+  const row = await db.one(
+    'SELECT title,mark,content,uid,time,isPublic FROM pastes WHERE mark=?',
+    [req.body.mark]
+  );
+  if (!row) return fail(res, '未找到');
+  if (req.session.gid < 3 && !row.isPublic && row.uid !== req.session.uid) {
+    return fail(res, '无权限查看');
+  }
+  row.time = Format(row.time);
+  const author = await db.one('SELECT name FROM userInfo WHERE uid=?', [row.uid]);
+  row.paster = author ? author.name : null;
+  return ok(res, { data: row });
+});
 
-exports.addPaste = (req, res) => {
+exports.addPaste = handler(async (req, res) => {
   const mark = getMark();
-  db.query('INSERT INTO pastes(mark,title,content,uid,time,isPublic) VALUES (?,?,?,?,?,?)', [mark, '请输入标题', '请输入内容', req.session.uid, new Date(), 0], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (data.affectedRows > 0)
-      return res.status(200).send({ mark: mark });
-    else
-      return res.status(202).send({ message: 'error' });
-  });
-}
+  const result = await db.query(
+    'INSERT INTO pastes(mark,title,content,uid,time,isPublic) VALUES (?,?,?,?,?,?)',
+    [mark, '请输入标题', '请输入内容', req.session.uid, new Date(), 0]
+  );
+  if (!result.affectedRows) return fail(res, 'error');
+  return ok(res, { mark });
+});
 
-exports.updatePaste = (req, res) => {
-  const paste = req.body.paste, content = paste.content, title = paste.title;
-  if (title.length > 20) {
-    return res.status(202).send({
-      message: '标题长度不可大于20'
-    });
+exports.updatePaste = handler(async (req, res) => {
+  const { paste } = req.body;
+  const { content, title } = paste;
+  if (title.length > 20) return fail(res, '标题长度不可大于20');
+  if (paste.length > 10000) return fail(res, '内容长度不可大于10000');
+
+  const owner = await db.one('SELECT uid FROM pastes WHERE mark=?', [paste.mark]);
+  if (!owner) return fail(res, '未找到');
+  if (req.session.gid < 3 && req.session.uid !== owner.uid) {
+    return fail(res, '你只能修改自己的paste');
   }
-  if (paste.length > 10000) {
-    return res.status(202).send({
-      message: '内容长度不可大于10000'
-    });
+
+  const result = await db.query(
+    'UPDATE pastes SET title=?,content=?,isPublic=?,time=? WHERE mark=?',
+    [title, content, paste.isPublic, new Date(), paste.mark]
+  );
+  if (!result.affectedRows) return fail(res, 'failed');
+  return ok(res);
+});
+
+exports.delPaste = handler(async (req, res) => {
+  const { mark } = req.body;
+  const owner = await db.one('SELECT uid FROM pastes WHERE mark=?', [mark]);
+  if (!owner) return fail(res, '未找到');
+  if (req.session.gid < 3 && req.session.uid !== owner.uid) {
+    return fail(res, '你只能删除自己的paste');
   }
-  db.query("SELECT uid FROM pastes WHERE mark=?", [paste.mark], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (req.session.gid < 3 && req.session.uid !== data[0].uid) return res.status(202).send({ message: '你只能修改自己的paste' });
-    db.query("UPDATE pastes SET title=?,content=?,isPublic=?,time=? WHERE mark=?", [title, content, paste.isPublic, new Date(), paste.mark], (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      if (data.affectedRows > 0) {
-        return res.status(200).send({
-          message: 'sueecss'
-        });
-      } else {
-        return res.status(202).send({
-          message: 'failed'
-        });
-      }
-    })
-  })
-}
+  const result = await db.query('DELETE FROM pastes WHERE mark=?', [mark]);
+  if (!result.affectedRows) return fail(res, 'failed');
+  return ok(res);
+});
 
-exports.delPaste = (req, res) => {
-  const mark = req.body.mark;
-  db.query("SELECT uid FROM pastes WHERE mark=?", [mark], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (req.session.gid < 3 && req.session.uid !== data[0].uid) return res.status(202).send({ message: '你只能删除自己的paste' });
-    db.query("DELETE FROM pastes WHERE mark=?", [mark], (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      if (data.affectedRows > 0) {
-        return res.status(200).send({
-          message: 'sueecss'
-        });
-      } else {
-        return res.status(202).send({
-          message: 'failed'
-        });
-      }
-    })
-  })
-}
-
-exports.getPasteList = (req, res) => {
-  let pageId = req.body.pageId,
-    pageSize = 20, uid = null;
-  if (req.body.uid) uid = req.body.uid;
-  if (!pageId) pageId = 1;
+exports.getPasteList = handler(async (req, res) => {
+  const { offset, limit } = paginate(req);
+  let uid = req.body.uid || null;
   if (req.session.gid < 3) uid = req.session.uid;
-  let sql = "SELECT p.id,p.mark,p.title,p.uid,p.time,p.isPublic,u.name as publisher FROM pastes p INNER JOIN userInfo u ON u.uid = p.uid";
-  if (uid) sql += ` WHERE p.uid=${uid}`;
-  sql += " ORDER BY p.id DESC LIMIT " + (pageId - 1) * pageSize + "," + pageSize;
-  db.query(sql, async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    let list = data;
-    for (let i = 0; i < list.length; i++)
-      list[i].time = Format(list[i].time);
-    sql = 'SELECT COUNT(*) as total FROM pastes';
-    if (uid) sql += ` WHERE uid=${uid}`;
-    db.query(sql, (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      return res.status(200).send({
-        total: data[0].total,
-        data: list
-      });
-    });
-  });
-}
 
-const hitokoto = require('../hitokoto/hitokoto.json'), len = hitokoto.length;
+  const cond = [['p.uid=?', uid]];
+  const { where, params } = buildWhere(cond);
+
+  const list = await db.query(
+    'SELECT p.id,p.mark,p.title,p.uid,p.time,p.isPublic,u.name as publisher ' +
+      'FROM pastes p INNER JOIN userInfo u ON u.uid = p.uid' +
+      `${where} ORDER BY p.id DESC LIMIT ?,?`,
+    [...params, offset, limit]
+  );
+  for (const r of list) r.time = Format(r.time);
+
+  const cntRow = await db.one(
+    `SELECT COUNT(*) as total FROM pastes p${where}`,
+    params
+  );
+  return ok(res, { total: cntRow.total, data: list });
+});
+
+const hitokoto = require('../hitokoto/hitokoto.json');
+const hitokotoLen = hitokoto.length;
 
 exports.getHitokoto = (req, res) => {
-  return res.status(200).send(hitokoto[randomInt(len)]);
-}
+  return res.status(200).send(hitokoto[randomInt(hitokotoLen)]);
+};

--- a/server/api/contest.js
+++ b/server/api/contest.js
@@ -1,872 +1,598 @@
-const db = require('../db/index');
-const { briefFormat, Format, kbFormat } = require('../static');
-const SqlString = require('mysql/lib/protocol/SqlString');
+const db = require('../db');
+const { handler, fail, ok, requireRole, paginate } = require('../db/util');
+const { Format, briefFormat, kbFormat } = require('../static');
+const { judgeRes, formatSubmissionRow, formatCaseRow, ctype, cstatus } = require('../db/format');
 const { pushSidIntoQueue } = require('./judge');
 const { getProblemLang } = require('./problem');
-const ctype = ['OI', 'IOI'];
-const cstatus = ['未开始', '正在进行', '等待测评', '已结束'];
-const ctypeToIndex = {
-  'OI': 0,
-  'IOI': 1
-}
-const contestStatus = (info) => {
-  if (info.done) return 3;
-  if (new Date().getTime() > info.start.getTime() + info.length * 1000 * 60)
-    return 2;
-  return (new Date().getTime() >= info.start.getTime() ? 1 : 0);
-}
 
-const isReg = (uid, cid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT * FROM contestPlayer WHERE uid=? AND cid=? LIMIT 1', [uid, cid], (err, data) => {
-      if (err) reject(err);
-      resolve(data.length);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-const getPinfo = (cid, idx) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT * FROM contestProblem WHERE cid=? AND idx=? LIMIT 1', [cid, idx], (err, data) => {
-      if (err) reject(err);
-      if (!data.length) resolve(false);
-      else resolve({
-        pid: data[0].pid,
-        id: data[0].id
-      });
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-const getIdx = (cid, pid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT * FROM contestProblem WHERE cid=? AND pid=? LIMIT 1', [cid, pid], (err, data) => {
-      if (err) reject(err);
-      if (!data.length) resolve(false);
-      else resolve(data[0].idx);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-exports.createContest = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  db.query('INSERT INTO contest(title,host,start,length,type,isPublic) VALUES (?,?,?,?,?,?)', [
-    '请输入比赛标题', req.session.uid, new Date(2121, 10, 22), 180, 0, 0], (err, data) => {
-      if (err) return res.status(202).send({
-        message: err
-      });
-      if (data.affectedRows > 0) {
-        return res.status(200).send({
-          cid: data.insertId
-        })
-      } else {
-        return res.status(202).send({
-          message: 'error',
-        })
-      }
-    });
-}
-
-exports.updateContestInfo = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  const cid = req.body.cid, info = req.body.info;
-
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], (err, contestInfo) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!contestInfo.length) {
-      return res.status(202).send({ message: '无此比赛' });
-    }
-    if (req.session.uid !== 1 && contestInfo[0].host !== req.session.uid) {
-      return res.status(202).send({ message: '你只能修改自己的比赛' });
-    }
-    if (contestInfo[0].done) {
-      return res.status(202).send({ message: '比赛已经结束' });
-    }
-    if (!info.title || !info.start || !info.length || !info.type) {
-      return res.status(202).send({
-        message: '请确认信息完善'
-      });
-    }
-    if (info.title.length > 30) {
-      return res.status(202).send({
-        message: '比赛名称最长30个字符'
-      });
-    }
-    if (info.type > 1) {
-      return res.status(202).send({
-        message: '非法比赛类型'
-      });
-    }
-    info.type = ctypeToIndex[info.type];
-    if (info.isPublic !== true && info.isPublic !== false) {
-      return res.status(202).send({
-        message: '非法isPublic参数'
-      });
-    }
-    db.query('UPDATE contest SET title=?,description=?,start=?,length=?,type=?,isPublic=?,lang=? WHERE cid=?',
-      [info.title, info.description, new Date(info.start), info.length, info.type, info.isPublic, info.lang, cid], (err, data) => {
-        if (err) return res.status(202).send({
-          message: err
-        });
-        if (data.affectedRows > 0) {
-          return res.status(200).send({
-            message: 'success',
-          })
-        } else {
-          return res.status(202).send({
-            message: 'error',
-          })
-        }
-      });
-  });
-}
-
-const getContestPlayerCnt = (cid) => {
-  return new Promise((resolve, reject) => {
-    db.query('SELECT COUNT(*) as cnt FROM contestPlayer WHERE cid=?', [cid], (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(data[0].cnt);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-exports.getContestList = (req, res) => {
-  let pageId = req.body.pageId,
-    pageSize = 20;
-  if (!pageId) pageId = 1;
-  pageId = SqlString.escape(pageId);
-  let sql = "SELECT c.cid,c.title,c.start,c.length,c.isPublic,c.type,c.host,c.done,u.name as hostName FROM contest c INNER JOIN userInfo u ON u.uid = c.host" +
-    " ORDER BY c.start DESC LIMIT " + (pageId - 1) * pageSize + "," + pageSize;
-  db.query(sql, async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    let list = data;
-    for (let i = 0; i < list.length; i++) {
-      list[i].type = ctype[list[i].type];
-      list[i].status = cstatus[contestStatus(list[i])];
-      list[i].start = Format(list[i].start);
-      list[i].playerCnt = await getContestPlayerCnt(list[i].cid);
-    }
-    db.query("SELECT COUNT(*) as total FROM contest", (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      return res.status(200).send({
-        total: data[0].total,
-        data: list
-      });
-    });
-  });
-}
-
-exports.getContestInfo = (req, res) => {
-  const cid = req.body.cid;
-  let sql = "SELECT c.cid,c.title,c.start,c.length,c.isPublic,c.type,c.host,c.description,c.lang,c.done,u.name as hostName FROM contest c INNER JOIN userInfo u ON u.uid = c.host WHERE cid=?";
-  db.query(sql, [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({
-      message: '无此比赛'
-    });
-    else {
-      data[0].isReg = await isReg(req.session.uid, data[0].cid);
-      if (!data[0].isPublic && !data[0].isReg && req.session.gid === 1)
-        return res.status(202).send({ message: '比赛私有，请联系管理员报名' });
-      data[0].playerCnt = await getContestPlayerCnt(data[0].cid);
-      data[0].status = contestStatus(data[0]);
-      data[0].end = Format(new Date(
-        new Date(data[0].start).getTime() + data[0].length * 1000 * 60
-      ));
-      data[0].regAble = (data[0].status < 2 && data[0].isPublic && !data[0].isReg);
-      data[0].auth = {
-        join: ((data[0].isReg && data[0].status > 0) || req.session.gid >= 2),
-        view: (data[0].status === 3 // 确认结束
-          || (data[0].isReg && data[0].type === 1 && data[0].status > 0) // IOI赛制 且 用户已报名
-          || req.session.gid >= 2)
-      }
-      // 一定要放在下面，因为在其之前会用到原始值
-      data[0].type = ctype[data[0].type];
-      data[0].start = Format(data[0].start);
-      data[0].status = cstatus[data[0].status];
-
-      return res.status(200).send({
-        data: data[0]
-      });
-    }
-  });
-}
-
-exports.addPlayer = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  const cid = req.body.cid, name = req.body.name;
-  db.query('SELECT uid FROM userInfo WHERE name=? LIMIT 1', [name], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({
-      message: '无此用户'
-    });
-    else {
-      db.query('SELECT * FROM contestPlayer WHERE cid=? AND uid=?', [cid, data[0].uid], (error, redata) => {
-        if (redata.length) return res.status(202).send({ message: '此用户已被添加入比赛' });
-        db.query('INSERT INTO contestPlayer(cid,uid) VALUES (?,?)', [cid, data[0].uid], (erro) => {
-          if (erro) return res.status(202).send({ message: erro });
-          return res.status(200).send({ message: 'success' });
-        });
-      })
-    }
-  });
-}
-
-exports.removePlayer = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  let rmIds = [];
-  for (let i = 0; i < req.body.list.length; i++) {
-    rmIds.push(req.body.list[i].id);
-  }
-  if (!rmIds.length)
-    return;
-  db.query('DELETE FROM contestPlayer WHERE id in(?)', [rmIds], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (data.affectedRows > 0)
-      res.status(200).send({ message: 'success' });
-    else res.status(202).send({ message: 'error' });
-  });
-}
-
-exports.getPlayerList = (req, res) => {
-  let pageId = req.body.pageId,
-    pageSize = 20;
-  if (!pageId) pageId = 1;
-  pageId = SqlString.escape(pageId);
-  const cid = req.body.cid;
-  let sql = "SELECT pl.id,pl.uid,u.name FROM contestPlayer pl INNER JOIN userInfo u ON u.uid = pl.uid WHERE pl.cid=?" +
-    " LIMIT " + (pageId - 1) * pageSize + "," + pageSize;
-  db.query(sql, [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    let list = data;
-    db.query("SELECT COUNT(*) as total FROM contestPlayer WHERE cid=?", [cid], (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      return res.status(200).send({
-        total: data[0].total,
-        data: list
-      });
-    });
-  });
-}
-
-exports.closeContest = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  const cid = req.body.cid;
-
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], (err, contestInfo) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!contestInfo.length) {
-      return res.status(202).send({ message: '无此比赛' });
-    }
-    if (req.session.uid !== 1 && contestInfo[0].host !== req.session.uid) {
-      return res.status(202).send({ message: '你只能修改自己的比赛' });
-    }
-    if (contestStatus(contestInfo[0]) < 2) {
-      return res.status(202).send({ message: '还未至比赛截止时间' });
-    }
-    if (contestStatus(contestInfo[0]) === 3) {
-      return res.status(202).send({ message: '比赛已结束' });
-    }
-    db.query('UPDATE contest SET done=1 WHERE cid=?', [cid], (err, data) => {
-      if (err) return res.status(202).send({
-        message: err
-      });
-      if (data.affectedRows > 0) {
-        return res.status(200).send({
-          message: 'success',
-        })
-      } else {
-        return res.status(202).send({
-          message: 'error',
-        })
-      }
-    });
-  });
-}
-
-exports.contestReg = (req, res) => {
-  const cid = req.body.cid;
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    if (!data[0].isPublic // 非公开
-      || contestStatus(data[0]) >= 2 // 正式结束
-      || (await isReg(req.session.uid, data[0].cid))) { // 已经报名
-      return res.status(202).send({ message: '比赛已结束或私有，请联系管理员' });
-    }
-    db.query('INSERT INTO contestPlayer(cid,uid) VALUES (?,?)', [cid, req.session.uid], (err2, data2) => {
-      if (err2) return res.status(202).send({ message: err2 });
-      return res.status(200).send({ message: 'success' });
-    });
-  });
-}
-
-exports.getPlayerProblemList = (req, res) => {
-  const cid = req.body.cid;
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    const isReged = await isReg(req.session.uid, data[0].cid);
-    if ((isReged && contestStatus(data[0]) > 0) || req.session.gid >= 2 || ((data[0].isPublic || isReged) && data[0].done)) {
-      db.query('SELECT cp.idx,p.title,cp.weight,p.publisher as publisherUid,u.name as publisher FROM contestProblem cp INNER JOIN problem p ON cp.pid = p.pid INNER JOIN userInfo u ON p.publisher = u.uid WHERE cp.cid=?', [cid], (err2, data2) => {
-        if (err2) return res.status(202).send({ message: err2 });
-        return res.status(200).send({
-          data: data2
-        });
-      })
-    }
-    else return res.status(403).end('403 Forbidden');
-  });
-}
-
+const ctypeToIndex = { OI: 0, IOI: 1 };
 const ptype = ['传统文本比较', 'Special Judge'];
 
-exports.getProblemInfo = (req, res) => {
-  const cid = req.body.cid, idx = req.body.idx;
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    const isReged = await isReg(req.session.uid, data[0].cid);
-    if ((isReged && contestStatus(data[0]) > 0) || req.session.gid >= 2 || ((data[0].isPublic || isReged) && data[0].done)) {
-      const pinfo = await getPinfo(cid, idx), pid = pinfo.pid;
-      if (!pid) return res.status(202).send({
-        message: '无此题目'
-      });
-      let sql = "SELECT p.title,p.description,p.time,p.timeLimit,p.memoryLimit,p.type,p.lang,p.publisher as publisherUid,u.name as publisher FROM problem p INNER JOIN userInfo u ON u.uid = p.publisher WHERE pid=?"
-      db.query(sql, [pid], async (err2, data2) => {
-        if (err2) return res.status(202).send({ message: err2 });
-        if (!data2.length) return res.status(202).send({
-          message: '无此题目'
-        });
-        else {
-          if (req.session.gid >= 2)
-            data2[0].pid = pid;
-          data2[0].lang = (await getProblemLang(pid)) & data[0].lang;
-          data2[0].type = ptype[data2[0].type];
-          data2[0].time = briefFormat(data2[0].time);
-          data2[0].idx = idx;
-          data2[0].id = pinfo.id;
-          return res.status(200).send({
-            data: data2[0]
-          });
-        }
-      });
-    }
-    else return res.status(403).end('403 Forbidden');
-  });
-}
+// ---- shared helpers ----
+const contestStatus = (info) => {
+  if (info.done) return 3;
+  if (Date.now() > info.start.getTime() + info.length * 1000 * 60) return 2;
+  return Date.now() >= info.start.getTime() ? 1 : 0;
+};
 
-exports.getProblemList = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  const cid = req.body.cid;
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    db.query('SELECT cp.idx,cp.pid,p.title,p.time,cp.weight,p.isPublic,p.publisher as publisherUid,u.name as publisher FROM contestProblem cp INNER JOIN problem p ON cp.pid = p.pid INNER JOIN userInfo u ON p.publisher = u.uid WHERE cp.cid=?', [cid], (err2, data2) => {
-      if (err2) return res.status(202).send({ message: err2 });
-      for (let i = 0; i < data2.length; i++) {
-        data2[i].time = briefFormat(data2[i].time);
-      }
-      return res.status(200).send({
-        data: data2
-      });
-    });
-  });
-}
+const isReg = (uid, cid) =>
+  db.exists('SELECT 1 FROM contestPlayer WHERE uid=? AND cid=? LIMIT 1', [uid, cid]);
 
+const playerCnt = async (cid) => {
+  const r = await db.one('SELECT COUNT(*) as cnt FROM contestPlayer WHERE cid=?', [cid]);
+  return r.cnt;
+};
 
-const addProblem = (problem, cid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('INSERT INTO contestProblem(cid,pid,idx,weight) VALUES (?,?,?,?)', [cid, problem.pid, problem.idx, problem.weight], (err, data) => {
-      if (err) reject(err);
-      resolve(true);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
+const getProblemByIdx = (cid, idx) =>
+  db.one('SELECT pid,id FROM contestProblem WHERE cid=? AND idx=? LIMIT 1', [cid, idx]);
 
+const getIdxByPid = async (cid, pid) => {
+  const r = await db.one('SELECT idx FROM contestProblem WHERE cid=? AND pid=? LIMIT 1', [cid, pid]);
+  return r ? r.idx : null;
+};
 
-exports.updateProblemList = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  const cid = req.body.cid, list = req.body.list;
-  let unilist = [], vis = [];
-  for (let i = 0; i < list.length; i++) {
-    if (!list[i].pid || !list[i].weight) {
-      return res.status(202).send({ message: '请确认信息完善' });
-    }
-    if (!vis[list[i].pid]) {
-      vis[list[i].pid] = true;
-      list[i].weight = parseInt(list[i].weight);
-      if (list[i].weight < 10 || list[i].weight > 10000) {
-        return res.status(202).send({ message: `题目#${list[i].pid}的满分应为[10,10000]之间的整数` });
-      }
-      unilist.push({
-        pid: list[i].pid,
-        weight: list[i].weight,
-        idx: i + 1
-      });
-    }
+const getContest = (cid) => db.one('SELECT * FROM contest WHERE cid=?', [cid]);
+
+// 主审核流程：可不可以查看比赛中的题目/提交。返回 { contest, status, isReged, canView } 或 null（无此比赛）
+const loadContestForView = async (req, cid) => {
+  const contest = await getContest(cid);
+  if (!contest) return null;
+  contest.status = contestStatus(contest);
+  const isReged = await isReg(req.session.uid, cid);
+  const canView =
+    (contest.status === 3 && (contest.isPublic || isReged)) ||
+    (isReged && contest.status > 0) ||
+    req.session.gid >= 2;
+  return { contest, status: contest.status, isReged, canView };
+};
+
+const formatContestSubmissionRow = async (r, ctx) => {
+  r.idx = await getIdxByPid(ctx.cid, r.pid);
+  r.pid = null;
+  r.submitTime = Format(r.submitTime);
+  if (!ctx.contest.type && !ctx.contest.done && ctx.gid === 1) {
+    r.score = r.judgeResult = r.time = r.memory = 0;
   }
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    if (req.session.uid !== 1 && data[0].host !== req.session.uid) {
-      return res.status(202).send({ message: '你只能修改自己的比赛' });
-    }
-    if (contestStatus(data[0]) === 3) {
-      return res.status(202).send({ message: '比赛已结束' });
-    }
-    db.query('DELETE FROM contestProblem WHERE cid=?', [cid], async () => {
-      for (let i = 0; i < unilist.length; i++) {
-        await addProblem(unilist[i], cid);
-      }
-      res.status(200).send({ message: 'success' });
-    });
-  })
-}
+  r.judgeResult = judgeRes[r.judgeResult];
+  r.memory = kbFormat(r.memory);
+  return r;
+};
 
-exports.submit = async (req, res) => {
-  const code = req.body.code, cid = req.body.cid, idx = req.body.idx, uid = req.session.uid, lang = req.body.lang;
-  if (!cid || !idx) {
-    return res.status(202).send({
-      message: '请确认信息完善'
-    });
+// ---- handlers ----
+exports.createContest = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const r = await db.query(
+      'INSERT INTO contest(title,host,start,length,type,isPublic) VALUES (?,?,?,?,?,?)',
+      ['请输入比赛标题', req.session.uid, new Date(2121, 10, 22), 180, 0, 0]
+    );
+    if (!r.affectedRows) return fail(res, 'error');
+    return ok(res, { cid: r.insertId });
+  }),
+];
+
+exports.updateContestInfo = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { cid, info } = req.body;
+    const contest = await getContest(cid);
+    if (!contest) return fail(res, '无此比赛');
+    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+      return fail(res, '你只能修改自己的比赛');
+    if (contest.done) return fail(res, '比赛已经结束');
+    if (!info.title || !info.start || !info.length || !info.type) return fail(res, '请确认信息完善');
+    if (info.title.length > 30) return fail(res, '比赛名称最长30个字符');
+    if (info.type > 1) return fail(res, '非法比赛类型');
+    info.type = ctypeToIndex[info.type];
+    if (info.isPublic !== true && info.isPublic !== false) return fail(res, '非法isPublic参数');
+
+    const r = await db.query(
+      'UPDATE contest SET title=?,description=?,start=?,length=?,type=?,isPublic=?,lang=? WHERE cid=?',
+      [info.title, info.description, new Date(info.start), info.length, info.type, info.isPublic, info.lang, cid]
+    );
+    if (!r.affectedRows) return fail(res, 'error');
+    return ok(res);
+  }),
+];
+
+exports.getContestList = handler(async (req, res) => {
+  const { offset, limit } = paginate(req);
+  const list = await db.query(
+    'SELECT c.cid,c.title,c.start,c.length,c.isPublic,c.type,c.host,c.done,u.name as hostName ' +
+      'FROM contest c INNER JOIN userInfo u ON u.uid = c.host ORDER BY c.start DESC LIMIT ?,?',
+    [offset, limit]
+  );
+  for (const c of list) {
+    c.type = ctype[c.type];
+    c.status = cstatus[contestStatus(c)];
+    c.start = Format(c.start);
+    c.playerCnt = await playerCnt(c.cid);
   }
-  if (code.length < 10) {
-    return res.status(202).send({
-      message: '代码太短'
-    });
-  }
-  if (code.length > 1024 * 100) {
-    return res.status(202).send({
-      message: '选手提交的程序源文件必须不大于 100KB。'
-    });
-  }
-  if (!(await isReg(uid, cid))) return res.status(202).send({
-    message: '请先报名比赛'
-  });
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    if (contestStatus(data[0]) !== 1) {
-      return res.status(202).send({ message: '非比赛时间' });
+  const cnt = await db.one('SELECT COUNT(*) as total FROM contest');
+  return ok(res, { total: cnt.total, data: list });
+});
+
+exports.getContestInfo = handler(async (req, res) => {
+  const { cid } = req.body;
+  const contest = await db.one(
+    'SELECT c.cid,c.title,c.start,c.length,c.isPublic,c.type,c.host,c.description,c.lang,c.done,u.name as hostName ' +
+      'FROM contest c INNER JOIN userInfo u ON u.uid = c.host WHERE cid=?',
+    [cid]
+  );
+  if (!contest) return fail(res, '无此比赛');
+
+  contest.isReg = await isReg(req.session.uid, contest.cid);
+  if (!contest.isPublic && !contest.isReg && req.session.gid === 1)
+    return fail(res, '比赛私有，请联系管理员报名');
+
+  contest.playerCnt = await playerCnt(contest.cid);
+  const status = contestStatus(contest);
+  contest.status = status;
+  contest.end = Format(new Date(new Date(contest.start).getTime() + contest.length * 1000 * 60));
+  contest.regAble = status < 2 && contest.isPublic && !contest.isReg;
+  contest.auth = {
+    join: (contest.isReg && status > 0) || req.session.gid >= 2,
+    view:
+      status === 3 ||
+      (contest.isReg && contest.type === 1 && status > 0) ||
+      req.session.gid >= 2,
+  };
+  contest.type = ctype[contest.type];
+  contest.start = Format(contest.start);
+  contest.status = cstatus[status];
+  return ok(res, { data: contest });
+});
+
+exports.addPlayer = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { cid, name } = req.body;
+    const user = await db.one('SELECT uid FROM userInfo WHERE name=? LIMIT 1', [name]);
+    if (!user) return fail(res, '无此用户');
+
+    const already = await db.exists(
+      'SELECT 1 FROM contestPlayer WHERE cid=? AND uid=?',
+      [cid, user.uid]
+    );
+    if (already) return fail(res, '此用户已被添加入比赛');
+
+    await db.query('INSERT INTO contestPlayer(cid,uid) VALUES (?,?)', [cid, user.uid]);
+    return ok(res);
+  }),
+];
+
+exports.removePlayer = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const ids = (req.body.list || []).map((x) => x.id);
+    if (!ids.length) return ok(res);
+    const r = await db.query('DELETE FROM contestPlayer WHERE id in(?)', [ids]);
+    if (!r.affectedRows) return fail(res, 'error');
+    return ok(res);
+  }),
+];
+
+exports.getPlayerList = handler(async (req, res) => {
+  const { offset, limit } = paginate(req);
+  const { cid } = req.body;
+  const list = await db.query(
+    'SELECT pl.id,pl.uid,u.name FROM contestPlayer pl INNER JOIN userInfo u ON u.uid = pl.uid WHERE pl.cid=? LIMIT ?,?',
+    [cid, offset, limit]
+  );
+  const cnt = await db.one('SELECT COUNT(*) as total FROM contestPlayer WHERE cid=?', [cid]);
+  return ok(res, { total: cnt.total, data: list });
+});
+
+exports.closeContest = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { cid } = req.body;
+    const contest = await getContest(cid);
+    if (!contest) return fail(res, '无此比赛');
+    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+      return fail(res, '你只能修改自己的比赛');
+    const status = contestStatus(contest);
+    if (status < 2) return fail(res, '还未至比赛截止时间');
+    if (status === 3) return fail(res, '比赛已结束');
+
+    const r = await db.query('UPDATE contest SET done=1 WHERE cid=?', [cid]);
+    if (!r.affectedRows) return fail(res, 'error');
+    return ok(res);
+  }),
+];
+
+exports.contestReg = handler(async (req, res) => {
+  const { cid } = req.body;
+  const contest = await getContest(cid);
+  if (!contest) return fail(res, '无此比赛');
+  const reged = await isReg(req.session.uid, contest.cid);
+  if (!contest.isPublic || contestStatus(contest) >= 2 || reged)
+    return fail(res, '比赛已结束或私有，请联系管理员');
+
+  await db.query('INSERT INTO contestPlayer(cid,uid) VALUES (?,?)', [cid, req.session.uid]);
+  return ok(res);
+});
+
+exports.getPlayerProblemList = handler(async (req, res) => {
+  const { cid } = req.body;
+  const contest = await getContest(cid);
+  if (!contest) return fail(res, '无此比赛');
+  const reged = await isReg(req.session.uid, contest.cid);
+  const status = contestStatus(contest);
+  const allowed =
+    (reged && status > 0) || req.session.gid >= 2 || ((contest.isPublic || reged) && contest.done);
+  if (!allowed) return res.status(403).end('403 Forbidden');
+
+  const data = await db.query(
+    'SELECT cp.idx,p.title,cp.weight,p.publisher as publisherUid,u.name as publisher ' +
+      'FROM contestProblem cp INNER JOIN problem p ON cp.pid = p.pid INNER JOIN userInfo u ON p.publisher = u.uid ' +
+      'WHERE cp.cid=?',
+    [cid]
+  );
+  return ok(res, { data });
+});
+
+exports.getProblemInfo = handler(async (req, res) => {
+  const { cid, idx } = req.body;
+  const v = await loadContestForView(req, cid);
+  if (!v) return fail(res, '无此比赛');
+  // 这里使用比赛进入条件，不是 view-only
+  const allowed =
+    (v.isReged && v.status > 0) ||
+    req.session.gid >= 2 ||
+    ((v.contest.isPublic || v.isReged) && v.contest.done);
+  if (!allowed) return res.status(403).end('403 Forbidden');
+
+  const pinfo = await getProblemByIdx(cid, idx);
+  if (!pinfo) return fail(res, '无此题目');
+
+  const problem = await db.one(
+    'SELECT p.title,p.description,p.time,p.timeLimit,p.memoryLimit,p.type,p.lang,p.publisher as publisherUid,u.name as publisher ' +
+      'FROM problem p INNER JOIN userInfo u ON u.uid = p.publisher WHERE pid=?',
+    [pinfo.pid]
+  );
+  if (!problem) return fail(res, '无此题目');
+
+  if (req.session.gid >= 2) problem.pid = pinfo.pid;
+  problem.lang = (await getProblemLang(pinfo.pid)) & v.contest.lang;
+  problem.type = ptype[problem.type];
+  problem.time = briefFormat(problem.time);
+  problem.idx = idx;
+  problem.id = pinfo.id;
+  return ok(res, { data: problem });
+});
+
+exports.getProblemList = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { cid } = req.body;
+    const contest = await getContest(cid);
+    if (!contest) return fail(res, '无此比赛');
+
+    const data = await db.query(
+      'SELECT cp.idx,cp.pid,p.title,p.time,cp.weight,p.isPublic,p.publisher as publisherUid,u.name as publisher ' +
+        'FROM contestProblem cp INNER JOIN problem p ON cp.pid = p.pid INNER JOIN userInfo u ON p.publisher = u.uid ' +
+        'WHERE cp.cid=?',
+      [cid]
+    );
+    for (const r of data) r.time = briefFormat(r.time);
+    return ok(res, { data });
+  }),
+];
+
+exports.updateProblemList = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { cid, list } = req.body;
+    const seen = {};
+    const unilist = [];
+    for (let i = 0; i < list.length; i++) {
+      const item = list[i];
+      if (!item.pid || !item.weight) return fail(res, '请确认信息完善');
+      if (seen[item.pid]) continue;
+      seen[item.pid] = true;
+      const weight = parseInt(item.weight, 10);
+      if (weight < 10 || weight > 10000)
+        return fail(res, `题目#${item.pid}的满分应为[10,10000]之间的整数`);
+      unilist.push({ pid: item.pid, weight, idx: i + 1 });
     }
-    const pinfo = await getPinfo(cid, idx), pid = pinfo.pid;
-    let alang = await getProblemLang(pid); // 题目lang
-    alang &= data[0].lang; // 比赛lang
-    if (!((1 << lang) & alang)) {
-      return res.status(202).send({
-        message: '非法语言'
-      });
-    }
-    if (req.body.id !== pinfo.id)
-      return res.status(202).send({
-        refresh: true,
-        message: '题目列表已更新，请重新查看题目列表提交'
-      });
-    db.query('INSERT INTO submission(pid,uid,code,codelength,submitTime,cid,lang) VALUES (?,?,?,?,?,?,?)', [pid, req.session.uid, code, code.length, new Date(), cid, lang], (err2, data2) => {
-      if (err2) return res.status(202).send({ message: err2 });
-      if (data2.affectedRows > 0) {
-        db.query('UPDATE problem SET submitCnt=submitCnt+1 WHERE pid=?', [pid]);
-        db.query('DELETE FROM contestLastSubmission WHERE cid=? AND uid=? AND pid=?', [cid, uid, pid], () => {
-          db.query('INSERT INTO contestLastSubmission (cid,uid,pid,sid) VALUES (?,?,?,?)', [cid, uid, pid, data2.insertId]);
-        });
-        pushSidIntoQueue(data2.insertId, false);
-        return res.status(200).send({
-          message: 'success'
-        })
-      } else {
-        return res.status(202).send({
-          message: 'error',
-        })
-      }
-    });
-  });
-}
+    const contest = await getContest(cid);
+    if (!contest) return fail(res, '无此比赛');
+    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+      return fail(res, '你只能修改自己的比赛');
+    if (contestStatus(contest) === 3) return fail(res, '比赛已结束');
 
-const judgeRes = ['Waiting',
-  'Pending',
-  'Rejudging',
-  'Compilation Error',
-  'Accepted',
-  'Wrong Answer',
-  'Time Limit Exceeded',
-  'Memory Limit Exceeded',
-  'Runtime Error',
-  'Segmentation Fault',
-  'Output Limit Exceeded',
-  'Dangerous System Call',
-  'System Error',
-  'Canceled',
-  'Skipped'];
-
-exports.getSubmissionList = (req, res) => {
-  const cid = req.body.cid, pageId = req.body.pageId, pageSize = 20;
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    data[0].status = contestStatus(data[0]);
-    const isReged = await isReg(req.session.uid, cid);
-    if (((data[0].status === 3 && (data[0].isPublic || isReged)) // 确认结束
-      || (isReged && data[0].status > 0) // 用户已报名
-      || req.session.gid >= 2)) {
-      let sql = 'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.machine,s.lang,u.name,p.title FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE cid=? ';
-      if (req.body.uid) {
-        sql += `AND u.uid=${req.body.uid}`;
-      }
-      sql += ' ORDER BY s.sid DESC LIMIT ?,?';
-      db.query(sql,
-        [cid, (pageId - 1) * pageSize, pageSize], async (err2, data2) => {
-          if (err2) return res.status(202).send({ message: err2 });
-          for (let i = 0; i < data2.length; i++) {
-            data2[i].idx = await getIdx(cid, data2[i].pid);
-            data2[i].pid = null;
-            data2[i].submitTime = Format(data2[i].submitTime);
-            if (!data[0].type && !data[0].done && req.session.gid === 1)
-              data2[i].score = data2[i].judgeResult = data2[i].time = data2[i].memory = 0;
-            data2[i].judgeResult = judgeRes[data2[i].judgeResult];
-            data2[i].memory = kbFormat(data2[i].memory);
-          }
-          db.query('SELECT COUNT(*) as cnt FROM submission WHERE cid=? ' + (req.body.uid ? `AND uid=${req.body.uid}` : ''),
-            [cid], async (err3, data3) => {
-              if (err3) return res.status(202).send({ message: err3.message });
-              return res.status(200).send({ data: data2, total: data3[0].cnt });
-            })
-        })
-    } else return res.status(403).end('403 Forbidden');
-  });
-}
-
-exports.getLastSubmissionList = (req, res) => {
-  const cid = req.body.cid, pageId = req.body.pageId, pageSize = 20;
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    data[0].status = contestStatus(data[0]);
-    const isReged = await isReg(req.session.uid, cid);
-    if (((data[0].status === 3 && (data[0].isPublic || isReged)) // 确认结束
-      || (isReged && data[0].status > 0) // IOI赛制 且 用户已报名
-      || req.session.gid >= 2)) {
-      let allLastSubmissions = await getAllSubmissions(cid), lastSubmissions = [];
-      for (let i = (pageId - 1) * pageSize; i < pageId * pageSize && i < allLastSubmissions.length; i++) {
-        lastSubmissions.push(allLastSubmissions[i].sid);
-      }
-      if (!lastSubmissions.length) {
-        return res.status(200).send({ data: [], total: 0 });
-      }
-      db.query('SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.machine,s.lang,u.name,p.title FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.sid in (?)',
-        [lastSubmissions], async (err2, data2) => {
-          if (err2) return res.status(202).send({ message: err2 });
-          for (let i = 0; i < data2.length; i++) {
-            data2[i].idx = await getIdx(cid, data2[i].pid);
-            data2[i].pid = null;
-            data2[i].submitTime = Format(data2[i].submitTime);
-            if (!data[0].type && !data[0].done && req.session.gid === 1)
-              data2[i].score = data2[i].judgeResult = data2[i].time = data2[i].memory = 0;
-            data2[i].judgeResult = judgeRes[data2[i].judgeResult];
-            data2[i].memory = kbFormat(data2[i].memory);
-          }
-          return res.status(200).send({ data: data2, total: allLastSubmissions.length });
-        });
-    } else return res.status(403).end('403 Forbidden');
-  });
-}
-
-const getCaseDetail = (sid) => {
-  return new Promise((resolve, reject) => {
-    db.query('SELECT * FROM submissionDetail WHERE sid=?', [sid], (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(data);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-
-exports.getSubmissionInfo = (req, res) => {
-  const sid = req.body.sid;
-  db.query('SELECT s.sid,s.uid,s.cid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.code,s.codeLength,s.submitTime,s.compileResult,s.caseResult,s.machine,s.lang,u.name,p.title FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE sid=?',
-    [sid], (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      if (!data.length) return res.status(202).send({
-        message: 'error'
-      });
-      else {
-        db.query('SELECT * FROM contest WHERE cid=?', [data[0].cid], async (err2, data2) => {
-          if (err2) return res.status(202).send({ message: err2 });
-          if (!data2.length) return res.status(202).send({ message: '无此比赛' });
-          data2[0].status = contestStatus(data2[0]);
-          if ((data2[0].status === 3 && (data2[0].isPublic || (await isReg(req.session.uid, data[0].cid)))) || req.session.uid === data[0].uid || req.session.gid > 1) {
-            data[0].caseResult = JSON.parse(data[0].caseResult);
-            data[0].singleCaseResult = await getCaseDetail(sid);
-            data[0].singleCaseResult.sort((a, b) => a.caseId - b.caseId);
-            data[0].done = false;
-            if (data[0].caseResult) {
-              let subtaskInfo = {};
-              for (let i in data[0].caseResult) {
-                data[0].caseResult[i].index = parseInt(data[0].caseResult[i].index);
-                data[0].caseResult[i].res = judgeRes[data[0].caseResult[i].res];
-                data[0].caseResult[i].memory = kbFormat(data[0].caseResult[i].memory);
-                subtaskInfo[data[0].caseResult[i].index] = new Map();
-                subtaskInfo[data[0].caseResult[i].index]['info'] = data[0].caseResult[i];
-                subtaskInfo[data[0].caseResult[i].index]['cases'] = [];
-              }
-              for (let i in data[0].singleCaseResult) {
-                data[0].singleCaseResult[i].result = judgeRes[data[0].singleCaseResult[i].result];
-                data[0].singleCaseResult[i].memory = kbFormat(data[0].singleCaseResult[i].memory);
-                if (!(req.session.gid > 1 || data2[0].status === 3)) {
-                  data[0].singleCaseResult[i].input = '正在比赛中...';
-                  data[0].singleCaseResult[i].output = '正在比赛中...';
-                  data[0].singleCaseResult[i].compareResult = '正在比赛中...';
-                }
-                subtaskInfo[data[0].singleCaseResult[i].subtaskId]['cases'].push(data[0].singleCaseResult[i]);
-              }
-              data[0].subtaskInfo = subtaskInfo;
-              data[0].done = true;
-              delete data[0].caseResult;
-              delete data[0].singleCaseResult;
-            } else {
-              for (let i in data[0].singleCaseResult) {
-                delete data[0].singleCaseResult[i].input;
-                delete data[0].singleCaseResult[i].output;
-                delete data[0].singleCaseResult[i].compareResult;
-                data[0].singleCaseResult[i].result = judgeRes[data[0].singleCaseResult[i].result];
-                data[0].singleCaseResult[i].memory = kbFormat(data[0].singleCaseResult[i].memory);
-              }
-            }
-            if (!data2[0].type && !data2[0].done && req.session.gid === 1) {
-              data[0].caseResult = data[0].singleCaseResult = data[0].subtaskInfo = null;
-              data[0].score = data[0].judgeResult = data[0].time = data[0].memory = 0;
-              data[0].unShown = true;
-            }
-            data[0].idx = await getIdx(data[0].cid, data[0].pid);
-            delete data[0].pid;
-            data[0].memory = kbFormat(data[0].memory);
-            data[0].submitTime = Format(data[0].submitTime);
-            data[0].judgeResult = judgeRes[data[0].judgeResult];
-            return res.status(200).send({
-              data: data[0]
-            });
-          } else return res.status(403).end('403 Forbidden');
-        })
+    await db.tx(async (tx) => {
+      await tx.query('DELETE FROM contestProblem WHERE cid=?', [cid]);
+      for (const p of unilist) {
+        await tx.query(
+          'INSERT INTO contestProblem(cid,pid,idx,weight) VALUES (?,?,?,?)',
+          [cid, p.pid, p.idx, p.weight]
+        );
       }
     });
-}
+    return ok(res);
+  }),
+];
 
-const getAllSubmissions = (cid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT sid FROM contestLastSubmission WHERE cid=?', [cid], (err, data) => {
-      if (err) reject(err);
-      resolve(data);
-    })
-  }).catch(err => {
-    console.log(err);
+exports.submit = handler(async (req, res) => {
+  const { code, cid, idx, lang } = req.body;
+  const uid = req.session.uid;
+  if (!cid || !idx) return fail(res, '请确认信息完善');
+  if (code.length < 10) return fail(res, '代码太短');
+  if (code.length > 1024 * 100) return fail(res, '选手提交的程序源文件必须不大于 100KB。');
+  if (!(await isReg(uid, cid))) return fail(res, '请先报名比赛');
+
+  const contest = await getContest(cid);
+  if (!contest) return fail(res, '无此比赛');
+  if (contestStatus(contest) !== 1) return fail(res, '非比赛时间');
+
+  const pinfo = await getProblemByIdx(cid, idx);
+  if (!pinfo) return fail(res, '无此题目');
+  let alang = await getProblemLang(pinfo.pid);
+  alang &= contest.lang;
+  if (!((1 << lang) & alang)) return fail(res, '非法语言');
+  if (req.body.id !== pinfo.id) {
+    return res.status(202).send({ refresh: true, message: '题目列表已更新，请重新查看题目列表提交' });
+  }
+
+  const insertId = await db.tx(async (tx) => {
+    const r = await tx.query(
+      'INSERT INTO submission(pid,uid,code,codelength,submitTime,cid,lang) VALUES (?,?,?,?,?,?,?)',
+      [pinfo.pid, uid, code, code.length, new Date(), cid, lang]
+    );
+    if (!r.affectedRows) throw new Error('insert failed');
+    await tx.query('UPDATE problem SET submitCnt=submitCnt+1 WHERE pid=?', [pinfo.pid]);
+    await tx.query(
+      'DELETE FROM contestLastSubmission WHERE cid=? AND uid=? AND pid=?',
+      [cid, uid, pinfo.pid]
+    );
+    await tx.query(
+      'INSERT INTO contestLastSubmission (cid,uid,pid,sid) VALUES (?,?,?,?)',
+      [cid, uid, pinfo.pid, r.insertId]
+    );
+    return r.insertId;
   });
-}
 
-const getUserAllSubmissions = (cid, uid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT sid FROM contestLastSubmission WHERE cid=? AND uid=?', [cid, uid], (err, data) => {
-      if (err) reject(err);
-      resolve(data);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
+  pushSidIntoQueue(insertId, false);
+  return ok(res);
+});
 
-const getAllProblems = (cid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT pid,idx,weight FROM contestProblem WHERE cid=?', [cid], (err, data) => {
-      if (err) reject(err);
-      resolve(data);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
+exports.getSubmissionList = handler(async (req, res) => {
+  const { cid } = req.body;
+  const { offset, limit } = paginate(req);
+  const v = await loadContestForView(req, cid);
+  if (!v) return fail(res, '无此比赛');
+  if (!v.canView) return res.status(403).end('403 Forbidden');
 
-const getAllPlayers = (cid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT uid FROM contestPlayer WHERE cid=?', [cid], async (err, data) => {
-      if (err) reject(err);
-      let users = [];
-      for (let i = 0; i < data.length; i++) {
-        users.push(data[i].uid);
-      }
-      resolve(await getAllPlayersInfo(users));
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
+  const params = [cid];
+  let extra = '';
+  if (req.body.uid) {
+    extra = ' AND u.uid=?';
+    params.push(req.body.uid);
+  }
+  const list = await db.query(
+    'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.machine,s.lang,u.name,p.title ' +
+      'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid ' +
+      `WHERE cid=?${extra} ORDER BY s.sid DESC LIMIT ?,?`,
+    [...params, offset, limit]
+  );
+  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  for (const r of list) await formatContestSubmissionRow(r, ctx);
 
-const getAllPlayersInfo = (list) => {
-  return new Promise((resolve, reject) => {
-    if (!list.length) resolve([]);
-    else {
-      return db.query('SELECT uid,name FROM userInfo WHERE uid in (?)', [list], (err, data) => {
-        if (err) reject(err);
-        resolve(data);
-      });
+  const cnt = await db.one(
+    `SELECT COUNT(*) as cnt FROM submission WHERE cid=?${req.body.uid ? ' AND uid=?' : ''}`,
+    req.body.uid ? [cid, req.body.uid] : [cid]
+  );
+  return ok(res, { data: list, total: cnt.cnt });
+});
+
+exports.getLastSubmissionList = handler(async (req, res) => {
+  const { cid } = req.body;
+  const { offset, limit } = paginate(req);
+  const v = await loadContestForView(req, cid);
+  if (!v) return fail(res, '无此比赛');
+  if (!v.canView) return res.status(403).end('403 Forbidden');
+
+  const allLast = await db.query('SELECT sid FROM contestLastSubmission WHERE cid=?', [cid]);
+  const sids = allLast.slice(offset, offset + limit).map((r) => r.sid);
+  if (!sids.length) return ok(res, { data: [], total: 0 });
+
+  const list = await db.query(
+    'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.machine,s.lang,u.name,p.title ' +
+      'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.sid in (?)',
+    [sids]
+  );
+  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  for (const r of list) await formatContestSubmissionRow(r, ctx);
+  return ok(res, { data: list, total: allLast.length });
+});
+
+exports.getSubmissionInfo = handler(async (req, res) => {
+  const { sid } = req.body;
+  const row = await db.one(
+    'SELECT s.sid,s.uid,s.cid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.code,s.codeLength,s.submitTime,s.compileResult,s.caseResult,s.machine,s.lang,u.name,p.title ' +
+      'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE sid=?',
+    [sid]
+  );
+  if (!row) return fail(res, 'error');
+
+  const contest = await getContest(row.cid);
+  if (!contest) return fail(res, '无此比赛');
+  contest.status = contestStatus(contest);
+  const reged = await isReg(req.session.uid, row.cid);
+  const allowed =
+    (contest.status === 3 && (contest.isPublic || reged)) ||
+    req.session.uid === row.uid ||
+    req.session.gid > 1;
+  if (!allowed) return res.status(403).end('403 Forbidden');
+
+  row.caseResult = JSON.parse(row.caseResult);
+  row.singleCaseResult = await db.query('SELECT * FROM submissionDetail WHERE sid=?', [sid]);
+  row.singleCaseResult.sort((a, b) => a.caseId - b.caseId);
+  row.done = false;
+
+  const fullView = req.session.gid > 1 || contest.status === 3;
+
+  if (row.caseResult) {
+    const subtaskInfo = {};
+    for (const c of row.caseResult) {
+      c.index = parseInt(c.index, 10);
+      c.res = judgeRes[c.res];
+      c.memory = kbFormat(c.memory);
+      subtaskInfo[c.index] = { info: c, cases: [] };
     }
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-const getSubmissionDetail = (sid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT uid,pid,time,score FROM submission WHERE sid=?', [sid], (err, data) => {
-      if (err) reject(err);
-      resolve(data[0]);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-const getContestInfo = (cid) => {
-  return new Promise((resolve, reject) => {
-    return db.query('SELECT * FROM contest WHERE cid=?', [cid], (err, data) => {
-      if (err) reject(err);
-      resolve(data[0]);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-exports.getRank = async (req, res) => {
-  const cid = req.body.cid,
-    submissions = await getAllSubmissions(cid),
-    problems = await getAllProblems(cid),
-    players = await getAllPlayers(cid),
-    contestInfo = await getContestInfo(cid),
-    isReged = await isReg(req.session.uid, cid),
-    status = contestStatus(contestInfo);
-
-  if (!(((status === 3 && (contestInfo.isPublic || isReged)) // 确认结束
-    || (isReged && contestInfo.type === 1 && status > 0) // IOI赛制 且 用户已报名
-    || req.session.gid >= 2))) {
-    return res.status(403).end('403 Forbidden');
-  }
-
-  let uVis = [], pidToIdx = [], pweight = [], rank = [], acVis = [], table = new Map(), pinfo = new Map();
-  for (let i = 0; i < problems.length; i++)
-    pidToIdx[problems[i].pid] = problems[i].idx, pweight[problems[i].pid] = problems[i].weight, pinfo[problems[i].idx] = problems[i].weight;
-  for (let i = 0; i < players.length; i++) {
-    uVis[players[i].uid] = true, table[players[i].uid] = new Map(), table[players[i].uid]['user'] = players[i],
-      table[players[i].uid]['totalScore'] = table[players[i].uid]['usedTime'] = 0,
-      table[players[i].uid]['detail'] = new Map(), table[players[i].uid]['submitted'] = false;
-  }
-  for (let i = 0; i < submissions.length; i++) {
-    submissions[i].detail = await getSubmissionDetail(submissions[i].sid);
-    if (pidToIdx[submissions[i].detail.pid] && uVis[submissions[i].detail.uid]) {
-      table[submissions[i].detail.uid]['detail'][pidToIdx[submissions[i].detail.pid]] = {
-        score: Math.round(submissions[i].detail.score * pweight[submissions[i].detail.pid] / 100),
-        time: submissions[i].detail.time
-      };
-      table[submissions[i].detail.uid]['totalScore'] += Math.round(submissions[i].detail.score * pweight[submissions[i].detail.pid] / 100);
-      if (submissions[i].detail.score)
-        table[submissions[i].detail.uid]['usedTime'] += submissions[i].detail.time;
-      if (submissions[i].detail.score === 100) {
-        if (!acVis[pidToIdx[submissions[i].detail.pid]])
-          table[submissions[i].detail.uid]['detail'][pidToIdx[submissions[i].detail.pid]].firstBlood = true;
-        acVis[pidToIdx[submissions[i].detail.pid]] = true;
+    for (const c of row.singleCaseResult) {
+      formatCaseRow(c);
+      if (!fullView) {
+        c.input = '正在比赛中...';
+        c.output = '正在比赛中...';
+        c.compareResult = '正在比赛中...';
       }
-      table[submissions[i].detail.uid]['submitted'] = true;
+      subtaskInfo[c.subtaskId]['cases'].push(c);
+    }
+    row.subtaskInfo = subtaskInfo;
+    row.done = true;
+    delete row.caseResult;
+    delete row.singleCaseResult;
+  } else {
+    for (const c of row.singleCaseResult) {
+      delete c.input;
+      delete c.output;
+      delete c.compareResult;
+      formatCaseRow(c);
     }
   }
-  for (let i in table) {
-    rank.push(table[i]);
+  // OI 赛制比赛中：选手只能看到提交时间，不能看到结果
+  if (!contest.type && !contest.done && req.session.gid === 1) {
+    row.caseResult = row.singleCaseResult = row.subtaskInfo = null;
+    row.score = row.judgeResult = row.time = row.memory = 0;
+    row.unShown = true;
   }
+  row.idx = await getIdxByPid(row.cid, row.pid);
+  delete row.pid;
+  formatSubmissionRow(row);
+  return ok(res, { data: row });
+});
+
+exports.getRank = handler(async (req, res) => {
+  const { cid } = req.body;
+  const submissions = await db.query('SELECT sid FROM contestLastSubmission WHERE cid=?', [cid]);
+  const problems = await db.query('SELECT pid,idx,weight FROM contestProblem WHERE cid=?', [cid]);
+  const playerUids = await db.column('SELECT uid FROM contestPlayer WHERE cid=?', [cid], 'uid');
+  const players = playerUids.length
+    ? await db.query('SELECT uid,name FROM userInfo WHERE uid in (?)', [playerUids])
+    : [];
+  const contest = await getContest(cid);
+  const reged = await isReg(req.session.uid, cid);
+  const status = contestStatus(contest);
+
+  const allowed =
+    (status === 3 && (contest.isPublic || reged)) ||
+    (reged && contest.type === 1 && status > 0) ||
+    req.session.gid >= 2;
+  if (!allowed) return res.status(403).end('403 Forbidden');
+
+  const pidToIdx = [];
+  const pweight = [];
+  const pinfo = new Map();
+  for (const p of problems) {
+    pidToIdx[p.pid] = p.idx;
+    pweight[p.pid] = p.weight;
+    pinfo[p.idx] = p.weight;
+  }
+
+  const uVis = [];
+  const table = new Map();
+  for (const u of players) {
+    uVis[u.uid] = true;
+    table[u.uid] = {
+      user: u,
+      totalScore: 0,
+      usedTime: 0,
+      detail: new Map(),
+      submitted: false,
+    };
+  }
+
+  const acVis = [];
+  for (const s of submissions) {
+    const detail = await db.one(
+      'SELECT uid,pid,time,score FROM submission WHERE sid=?',
+      [s.sid]
+    );
+    if (!detail) continue;
+    const idx = pidToIdx[detail.pid];
+    if (!idx || !uVis[detail.uid]) continue;
+    const score = Math.round((detail.score * pweight[detail.pid]) / 100);
+    table[detail.uid].detail[idx] = { score, time: detail.time };
+    table[detail.uid].totalScore += score;
+    if (detail.score) table[detail.uid].usedTime += detail.time;
+    if (detail.score === 100) {
+      if (!acVis[idx]) table[detail.uid].detail[idx].firstBlood = true;
+      acVis[idx] = true;
+    }
+    table[detail.uid].submitted = true;
+  }
+
+  const rank = [];
+  for (const uid in table) rank.push(table[uid]);
   rank.sort((a, b) => {
-    if (a.totalScore === b.totalScore) {
-      if (a.usedTime === b.usedTime) {
-        if (a.submitted === b.submitted) {
-          return a.uid - b.uid;
-        } else return b.submitted - a.submitted;
-      } else return a.usedTime - b.usedTime; //升序
-    } else return b.totalScore - a.totalScore; //降序
+    if (a.totalScore !== b.totalScore) return b.totalScore - a.totalScore;
+    if (a.usedTime !== b.usedTime) return a.usedTime - b.usedTime;
+    if (a.submitted !== b.submitted) return b.submitted - a.submitted;
+    return a.user.uid - b.user.uid;
   });
-  return res.status(200).send({ data: rank, problem: pinfo });
-}
+  return ok(res, { data: rank, problem: pinfo });
+});
 
-exports.getSingleUserLastSubmission = async (req, res) => {
-  const cid = req.body.cid, uid = req.body.uid;
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    data[0].status = contestStatus(data[0]);
-    const isReged = await isReg(req.session.uid, cid);
-    if (((data[0].status === 3 && (data[0].isPublic || isReged)) // 确认结束
-      || (isReged && data[0].status > 0) // 用户已报名
-      || req.session.gid >= 2)) {
-      let lastSubmission = await getUserAllSubmissions(cid, uid), lastSubmissions = [];
-      for (let i in lastSubmission) {
-        lastSubmissions.push(lastSubmission[i].sid);
-      }
-      if (!lastSubmissions.length) {
-        return res.status(200).send({ data: [], total: 0 });
-      }
-      db.query('SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.machine,s.lang,u.name,p.title FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.sid in (?)',
-        [lastSubmissions], async (err2, data2) => {
-          if (err2) return res.status(202).send({ message: err2 });
-          for (let i = 0; i < data2.length; i++) {
-            data2[i].idx = await getIdx(cid, data2[i].pid);
-            data2[i].pid = null;
-            data2[i].submitTime = Format(data2[i].submitTime);
-            if (!data[0].type && !data[0].done && req.session.gid === 1)
-              data2[i].score = data2[i].judgeResult = data2[i].time = data2[i].memory = 0;
-            data2[i].judgeResult = judgeRes[data2[i].judgeResult];
-            data2[i].memory = kbFormat(data2[i].memory);
-          }
-          return res.status(200).send({ data: data2 });
-        });
-    } else return res.status(403).end('403 Forbidden');
-  });
-}
+exports.getSingleUserLastSubmission = handler(async (req, res) => {
+  const { cid, uid } = req.body;
+  const v = await loadContestForView(req, cid);
+  if (!v) return fail(res, '无此比赛');
+  if (!v.canView) return res.status(403).end('403 Forbidden');
 
-exports.getSingleUserProblemSubmission = (req, res) => {
-  const cid = req.body.cid, uid = req.body.uid, idx = req.body.idx;
-  db.query('SELECT * FROM contest WHERE cid=?', [cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({ message: '无此比赛' });
-    data[0].status = contestStatus(data[0]);
-    const isReged = await isReg(req.session.uid, cid);
-    if (((data[0].status === 3 && (data[0].isPublic || isReged)) // 确认结束
-      || (isReged && data[0].status > 0) // 用户已报名
-      || req.session.gid >= 2)) {
-      const pinfo = await getPinfo(cid, idx);
-      db.query('SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.machine,s.lang,u.name,p.title FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.cid=? AND s.uid=? AND s.pid=? ORDER BY s.sid DESC',
-        [cid, uid, pinfo.pid], async (err2, data2) => {
-          if (err2) return res.status(202).send({ message: err2 });
-          for (let i = 0; i < data2.length; i++) {
-            data2[i].idx = idx;
-            data2[i].pid = null;
-            data2[i].submitTime = Format(data2[i].submitTime);
-            if (!data[0].type && !data[0].done && req.session.gid === 1)
-              data2[i].score = data2[i].judgeResult = data2[i].time = data2[i].memory = 0;
-            data2[i].judgeResult = judgeRes[data2[i].judgeResult];
-            data2[i].memory = kbFormat(data2[i].memory);
-          }
-          return res.status(200).send({ data: data2 });
-        })
-    } else return res.status(403).end('403 Forbidden');
-  });
-}
+  const sids = await db.column(
+    'SELECT sid FROM contestLastSubmission WHERE cid=? AND uid=?',
+    [cid, uid],
+    'sid'
+  );
+  if (!sids.length) return ok(res, { data: [], total: 0 });
+
+  const list = await db.query(
+    'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.machine,s.lang,u.name,p.title ' +
+      'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.sid in (?)',
+    [sids]
+  );
+  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  for (const r of list) await formatContestSubmissionRow(r, ctx);
+  return ok(res, { data: list });
+});
+
+exports.getSingleUserProblemSubmission = handler(async (req, res) => {
+  const { cid, uid, idx } = req.body;
+  const v = await loadContestForView(req, cid);
+  if (!v) return fail(res, '无此比赛');
+  if (!v.canView) return res.status(403).end('403 Forbidden');
+
+  const pinfo = await getProblemByIdx(cid, idx);
+  if (!pinfo) return fail(res, '无此题目');
+
+  const list = await db.query(
+    'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.machine,s.lang,u.name,p.title ' +
+      'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid ' +
+      'WHERE s.cid=? AND s.uid=? AND s.pid=? ORDER BY s.sid DESC',
+    [cid, uid, pinfo.pid]
+  );
+  for (const r of list) {
+    r.idx = idx;
+    r.pid = null;
+    r.submitTime = Format(r.submitTime);
+    if (!v.contest.type && !v.contest.done && req.session.gid === 1) {
+      r.score = r.judgeResult = r.time = r.memory = 0;
+    }
+    r.judgeResult = judgeRes[r.judgeResult];
+    r.memory = kbFormat(r.memory);
+  }
+  return ok(res, { data: list });
+});

--- a/server/api/judge.js
+++ b/server/api/judge.js
@@ -1,473 +1,266 @@
 const axios = require('axios');
-const db = require('../db/index');
-const SqlString = require('mysql/lib/protocol/SqlString');
-const exec = require('child_process').exec;
-const { Format, kbFormat, queryPromise } = require('../static');
 const async = require('async');
-const conf = require('../config.json');
+const { exec } = require('child_process');
 const { fork } = require('child_process');
+const db = require('../db');
+const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
+const { Format, kbFormat } = require('../static');
+const conf = require('../config.json');
 const { updateProblemStat, problemAuth, getProblemLang } = require('./problem');
+const { judgeRes, formatSubmissionRow, formatCaseRow } = require('../db/format');
 
+// ---- judging queue ----
 const judgeQueue = async.queue((submission, callback) => {
-
   const worker = fork(`./api/judgeWorker(${submission.lang}).js`);
-
   worker.on('message', (msg) => {
     if (msg.type === 'done' || msg.type === 'error') {
       worker.kill();
       callback();
     }
   });
-
   worker.on('error', (error) => {
     console.error(`Worker error for submission ${submission.sid}:`, error);
     worker.kill();
     callback(error);
   });
-
   worker.send({ type: 'judge', sid: submission.sid, isreJudge: submission.isreJudge });
 }, 4);
 
-const machines = [
-  'localhost',
-  // 'http://49.235.101.43/api/judge/receiveTask'
-];
-
-
-exports.receiveTask = (req, res) => {
-  if (conf.JUDGE.ISSERVER)
-    return res.status(202).send({ message: 'This is SERVER' });
-  pushSidIntoQueue(req.body.sid, req.body.isreJudge);
-  return res.status(200).send({ message: 'ok' });
-}
-
+const machines = ['localhost'];
 let taskId = 0;
 
 const pushSidIntoQueue = async (sid, isreJudge) => {
-  const lang = await queryPromise('SELECT l.name FROM languages l INNER JOIN submission s ON l.id = s.lang WHERE s.sid=?', [sid]);
+  const lang = await db.one(
+    'SELECT l.name FROM languages l INNER JOIN submission s ON l.id = s.lang WHERE s.sid=?',
+    [sid]
+  );
   if (conf.JUDGE.ISSERVER) {
-    const machine = machines[(++taskId) % machines.length];
+    const machine = machines[++taskId % machines.length];
     if (machine === 'localhost') {
       console.log(Format(new Date()), 'server: localJudge', sid);
-      judgeQueue.push({ sid: sid, isreJudge: isreJudge, lang: lang[0].name });
-    }
-    else {
+      judgeQueue.push({ sid, isreJudge, lang: lang.name });
+    } else {
       console.log(Format(new Date()), 'server: task assigned to', machine, sid);
-      axios.post(machine, { sid: sid, isreJudge: isreJudge }).then(res => {
-        if (res.status === 200)
-          console.log(Format(new Date()), 'server: ', machine, 'ok', sid);
-        else {
-          console.log(Format(new Date()), 'server: ', machine, 'error: return status not 200', res, sid);
+      try {
+        const r = await axios.post(machine, { sid, isreJudge });
+        if (r.status === 200) {
+          console.log(Format(new Date()), 'server:', machine, 'ok', sid);
+        } else {
+          console.log(Format(new Date()), 'server:', machine, 'error: status not 200', r, sid);
           pushSidIntoQueue(sid, isreJudge);
         }
-      }).catch(err => {
-        console.log(Format(new Date()), 'server: ', machine, 'error: ', err, sid);
+      } catch (err) {
+        console.log(Format(new Date()), 'server:', machine, 'error:', err, sid);
         pushSidIntoQueue(sid, isreJudge);
-      });
+      }
     }
   } else {
     console.log(Format(new Date()), 'client: task received', sid, isreJudge);
-    judgeQueue.push({ sid: sid, isreJudge: isreJudge, lang: lang[0].name });
+    judgeQueue.push({ sid, isreJudge, lang: lang.name });
   }
-}
-module.exports.pushSidIntoQueue = pushSidIntoQueue;
+};
+exports.pushSidIntoQueue = pushSidIntoQueue;
 
-const judgeRes = ['Waiting',
-  'Pending',
-  'Rejudging',
-  'Compilation Error',
-  'Accepted',
-  'Wrong Answer',
-  'Time Limit Exceeded',
-  'Memory Limit Exceeded',
-  'Runtime Error',
-  'Segmentation Fault',
-  'Output Limit Exceeded',
-  'Dangerous System Call',
-  'System Error',
-  'Canceled',
-  'Skipped'];
+// ---- shared helpers (also used by judgeWorkers) ----
+exports.SubmissionInfo = (sid) => db.one('SELECT * FROM submission WHERE sid=?', [sid]);
+exports.ProblemInfo = (pid) => db.one('SELECT * FROM problem WHERE pid=?', [pid]);
 
-const SubmissionInfo = (sid) => {
-  return new Promise((resolve, reject) => {
-    db.query('SELECT * FROM submission WHERE sid=?', [sid], (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(data[0]);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-module.exports.SubmissionInfo = SubmissionInfo;
-
-
-const ProblemInfo = (pid) => {
-  return new Promise((resolve, reject) => {
-    db.query('SELECT * FROM problem WHERE pid=?', [pid], (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(data[0]);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-module.exports.ProblemInfo = ProblemInfo;
-
-const getCompareResult = (fileSuf) => {
-  return new Promise((resolve, reject) => {
+exports.getCompareResult = (fileSuf) =>
+  new Promise((resolve) => {
     exec(`./comparer/comparer ./comparer/data.in ${fileSuf}usr.out ${fileSuf}data.out`, (err, stdout, stderr) => {
       resolve(stderr);
     });
-  }).catch(err => {
+  });
+
+exports.setSubmission = (sid, judgeResult, time, memory, score, compileResult, caseResult, machine) =>
+  db.query(
+    'UPDATE submission SET judgeResult=?,time=?,memory=?,score=?,compileResult=?,caseResult=?,machine=? WHERE sid=?',
+    [judgeResult, time, memory, score, compileResult, caseResult, machine, sid]
+  ).then((r) => r.affectedRows).catch((err) => console.log(err));
+
+exports.updateSubmissionDetail = (sid, caseId, input, output, time, memory, result, compareResult, subtaskId) =>
+  db.query(
+    'INSERT INTO submissionDetail(sid,caseId,input,output,time,memory,result,compareResult,subtaskId) values(?,?,?,?,?,?,?,?,?)',
+    [sid, caseId, input, output, time, memory, result, compareResult, subtaskId]
+  ).catch((err) => console.log(err));
+
+exports.updateProblemSubmitInfo = async (pid) => {
+  try {
+    const total = await db.one('SELECT COUNT(*) as cnt FROM submission WHERE pid=?', [pid]);
+    await db.query('UPDATE problem SET submitCnt=? WHERE pid=?', [total.cnt, pid]);
+    const ac = await db.one('SELECT COUNT(*) as cnt FROM submission WHERE pid=? AND judgeResult=4', [pid]);
+    await db.query('UPDATE problem SET acCnt=? WHERE pid=?', [ac.cnt, pid]);
+  } catch (err) {
     console.log(err);
-  });
-}
-module.exports.getCompareResult = getCompareResult;
-
-const setSubmission = (sid, judgeResult, time, memory, score, compileResult, caseResult, machine) => {
-  return new Promise((resolve, reject) => {
-    db.query('UPDATE submission SET judgeResult=?,time=?,memory=?,score=?,compileResult=?,caseResult=?,machine=? WHERE sid=?',
-      [judgeResult, time, memory, score, compileResult, caseResult, machine, sid,], (err, data) => {
-        if (err) {
-          reject(err);
-        }
-        resolve(data.affectedRows);
-      })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-module.exports.setSubmission = setSubmission;
-
-
-const updateSubmissionDetail = (sid, caseId, input, output, time, memory, result, compareResult, subtaskId) => {
-  return new Promise((resolve, reject) => {
-    db.query('INSERT INTO submissionDetail(sid,caseId,input,output,time,memory,result,compareResult,subtaskId) values(?,?,?,?,?,?,?,?,?)',
-      [sid, caseId, input, output, time, memory, result, compareResult, subtaskId], (err, data) => {
-        if (err) reject(err);
-        else resolve(data);
-      });
-  }).catch(err => {
-    console.log(err);
-  });
-}
-module.exports.updateSubmissionDetail = updateSubmissionDetail;
-
-const updateProblemSubmitInfo = async (pid) => {
-  await new Promise((resolve, reject) => {
-    db.query('SELECT COUNT(*) as cnt FROM submission WHERE pid=?', [pid], (err, data) => {
-      db.query('UPDATE problem SET submitCnt=? WHERE pid=?', [data[0].cnt, pid], (err, data) => {
-        if (err) reject(err);
-        else resolve(data);
-      });
-    });
-  }).catch(err => {
-    console.log(err);
-  });
-  await new Promise((resolve, reject) => {
-    db.query('SELECT COUNT(*) as cnt FROM submission WHERE pid=? AND judgeResult=4', [pid], (err, data) => {
-      db.query('UPDATE problem SET acCnt=? WHERE pid=?', [data[0].cnt, pid], (err, data) => {
-        if (err) reject(err);
-        else resolve(data);
-      });
-    });
-  }).catch(err => {
-    console.log(err);
-  });
-  return;
-}
-module.exports.updateProblemSubmitInfo = updateProblemSubmitInfo;
-
-const clearCase = (sid) => {
-  return new Promise((resolve, reject) => {
-    db.query('DELETE FROM submissionDetail WHERE sid=?', [sid], (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(data);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-module.exports.clearCase = clearCase;
-
-const updateData = (pid) => {
-  return new Promise((resolve, reject) => {
-    exec(`./sync_data.sh ${pid}`, (err, stdout, stderr) => {
-      resolve(stdout);
-    });
-  }).catch(err => {
-    console.log(err);
-  });
-}
-module.exports.updateData = updateData;
-
-exports.submit = async (req, res) => {
-  const code = req.body.code, pid = req.body.pid, lang = req.body.lang;
-  if (!pid) {
-    return res.status(202).send({
-      message: '请确认信息完善'
-    });
   }
-  if (!(await problemAuth(req, pid))) {
-    return res.status(202).send({
-      message: '权限不足'
-    });
-  }
-  if (code.length < 10) {
-    return res.status(202).send({
-      message: '代码太短'
-    });
-  }
-  if (code.length > 1024 * 100) {
-    return res.status(202).send({
-      message: '选手提交的程序源文件必须不大于 100KB。'
-    });
-  }
-  let alang = await getProblemLang(pid);
-  if (!((1 << lang) & alang)) {
-    return res.status(202).send({
-      message: '非法语言'
-    });
-  }
-  db.query('INSERT INTO submission(pid,uid,code,codelength,submitTime,lang) VALUES (?,?,?,?,?,?)', [pid, req.session.uid, code, code.length, new Date(), lang], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    if (data.affectedRows > 0) {
-      db.query("UPDATE problem SET submitCnt=submitCnt+1 WHERE pid=?", [pid]);
-      pushSidIntoQueue(data.insertId, false);
-      return res.status(200).send({
-        sid: data.insertId
-      })
-    } else {
-      return res.status(202).send({
-        message: 'error',
-      })
+};
+
+exports.clearCase = (sid) =>
+  db.query('DELETE FROM submissionDetail WHERE sid=?', [sid]).catch((err) => console.log(err));
+
+exports.updateData = (pid) =>
+  new Promise((resolve) => {
+    exec(`./sync_data.sh ${pid}`, (err, stdout) => resolve(stdout));
+  });
+
+const getCaseDetail = (sid) => db.query('SELECT * FROM submissionDetail WHERE sid=?', [sid]);
+
+// ---- handlers ----
+exports.receiveTask = handler(async (req, res) => {
+  if (conf.JUDGE.ISSERVER) return fail(res, 'This is SERVER');
+  pushSidIntoQueue(req.body.sid, req.body.isreJudge);
+  return ok(res, { message: 'ok' });
+});
+
+exports.submit = handler(async (req, res) => {
+  const { code, pid, lang } = req.body;
+  if (!pid) return fail(res, '请确认信息完善');
+  const auth = await problemAuth(req, pid);
+  if (!auth.view) return fail(res, '权限不足');
+  if (code.length < 10) return fail(res, '代码太短');
+  if (code.length > 1024 * 100) return fail(res, '选手提交的程序源文件必须不大于 100KB。');
+
+  const alang = await getProblemLang(pid);
+  if (!((1 << lang) & alang)) return fail(res, '非法语言');
+
+  const r = await db.query(
+    'INSERT INTO submission(pid,uid,code,codelength,submitTime,lang) VALUES (?,?,?,?,?,?)',
+    [pid, req.session.uid, code, code.length, new Date(), lang]
+  );
+  if (!r.affectedRows) return fail(res, 'error');
+
+  await db.query('UPDATE problem SET submitCnt=submitCnt+1 WHERE pid=?', [pid]);
+  pushSidIntoQueue(r.insertId, false);
+  return ok(res, { sid: r.insertId });
+});
+
+exports.getSubmissionList = handler(async (req, res) => {
+  const { offset, limit } = paginate(req);
+  const visibility = req.session.gid < 2 ? 'p.isPublic=1' : 'p.isPublic<6';
+
+  // 只有 queryAll && gid!=1 才能跨比赛查询；否则强制 cid=0
+  const restrictToNoContest = !req.body.queryAll || req.session.gid === 1;
+  const cond = [
+    restrictToNoContest ? ['s.cid=0'] : ['s.cid=?', req.body.cid],
+    ['u.name=?', req.body.name],
+    ['p.pid=?', req.body.pid],
+    req.body.judgeRes != null ? ['s.judgeResult=?', req.body.judgeRes] : null,
+    req.body.score != null ? ['s.score=?', req.body.score] : null,
+    req.body.lang != null ? ['s.lang=?', req.body.lang] : null,
+  ];
+  const { where, params } = buildWhere(cond, visibility);
+
+  const list = await db.query(
+    'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.cid,s.machine,s.lang,u.name,p.title,p.isPublic ' +
+      'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid' +
+      `${where} ORDER BY sid DESC LIMIT ?,?`,
+    [...params, offset, limit]
+  );
+  for (const r of list) formatSubmissionRow(r);
+
+  const cnt = await db.one(
+    'SELECT COUNT(*) as total FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid' +
+      where,
+    params
+  );
+  return ok(res, { total: cnt.total, data: list });
+});
+
+exports.getSubmissionInfo = handler(async (req, res) => {
+  const { sid } = req.body;
+  const visibility = req.session.gid < 2 ? ' AND p.isPublic=1' : '';
+  const row = await db.one(
+    'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.code,s.codeLength,s.submitTime,s.compileResult,s.caseResult,s.machine,s.lang,u.name,p.title,p.isPublic ' +
+      'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid ' +
+      `WHERE sid=?${visibility} AND s.cid=0`,
+    [sid]
+  );
+  if (!row) return fail(res, 'error');
+
+  row.caseResult = JSON.parse(row.caseResult);
+  row.singleCaseResult = await getCaseDetail(sid);
+  row.singleCaseResult.sort((a, b) => a.caseId - b.caseId);
+  row.done = false;
+
+  if (row.caseResult) {
+    const subtaskInfo = {};
+    for (const c of row.caseResult) {
+      c.index = parseInt(c.index, 10);
+      c.res = judgeRes[c.res];
+      c.memory = kbFormat(c.memory);
+      subtaskInfo[c.index] = { info: c, cases: [] };
     }
-  });
-}
-
-exports.getSubmissionList = (req, res) => {
-  let pageId = req.body.pageId,
-    pageSize = 20;
-  if (!pageId) pageId = 1;
-  let sql = "SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.cid,s.machine,s.lang,u.name,p.title,p.isPublic FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid "
-
-  pageId = SqlString.escape(pageId);
-
-  sql += 'WHERE p.isPublic' + (req.session.gid < 2 ? '=1' : '<6');
-  if (!req.body.queryAll || req.session.gid === 1)
-    sql += ' AND s.cid=0';
-  else if (req.body.cid) {
-    req.body.cid = SqlString.escape(req.body.cid);
-    sql += ` AND s.cid=${req.body.cid}`;
+    for (const c of row.singleCaseResult) {
+      formatCaseRow(c);
+      subtaskInfo[c.subtaskId]['cases'].push(c);
+    }
+    row.subtaskInfo = subtaskInfo;
+    row.done = true;
+    delete row.caseResult;
+    delete row.singleCaseResult;
+  } else {
+    for (const c of row.singleCaseResult) formatCaseRow(c);
   }
-  if (req.body.name) {
-    req.body.name = SqlString.escape(req.body.name);
-    sql += ' AND u.name=' + req.body.name;
-  }
-  if (req.body.pid) {
-    req.body.pid = SqlString.escape(req.body.pid);
-    sql += ' AND p.pid=' + req.body.pid;
-  }
-  if (req.body.judgeRes !== null) {
-    req.body.judgeRes = SqlString.escape(req.body.judgeRes);
-    sql += ' AND s.judgeResult=' + req.body.judgeRes;
-  }
-  if (req.body.score !== null) {
-    req.body.score = SqlString.escape(req.body.score);
-    sql += ' AND s.score=' + req.body.score;
-  }
-  if (req.body.lang !== null) {
-    req.body.lang = SqlString.escape(req.body.lang);
-    sql += ' AND s.lang=' + req.body.lang;
-  }
-  sql += " ORDER BY sid DESC LIMIT " + (pageId - 1) * pageSize + "," + pageSize;
+  formatSubmissionRow(row);
+  return ok(res, { data: row });
+});
 
-  db.query(sql, (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    let list = data;
-    for (let i = 0; i < list.length; i++) {
-      list[i].submitTime = Format(list[i].submitTime);
-      list[i].judgeResult = judgeRes[list[i].judgeResult];
-      list[i].memory = kbFormat(list[i].memory);
+exports.reJudge = [
+  requireRole(2),
+  handler(async (req, res) => {
+    await exports.setSubmission(req.body.sid, 2, 0, 0, 0, null, null);
+    pushSidIntoQueue(req.body.sid, true);
+    await exports.clearCase(req.body.sid);
+    return ok(res, { message: 'ok' });
+  }),
+];
+
+exports.reJudgeProblem = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { pid } = req.body;
+    const list = await db.query('SELECT sid FROM submission WHERE pid=?', [pid]);
+    for (const s of list) {
+      exports.setSubmission(s.sid, 2, 0, 0, 0, null, null);
+      pushSidIntoQueue(s.sid, true);
     }
-    let cntsql = "SELECT COUNT(*) as total FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid ";
-    cntsql += 'WHERE p.isPublic' + (req.session.gid < 2 ? '=1' : '<6');
+    updateProblemStat(pid);
+    exports.updateProblemSubmitInfo(pid);
+    return ok(res, { message: 'ok', total: list.length });
+  }),
+];
 
-    if (!req.body.queryAll || req.session.gid === 1)
-      cntsql += ' AND s.cid=0';
-    else if (req.body.cid)
-      cntsql += ' AND s.cid=' + req.body.cid;
-    if (req.body.name) {
-      cntsql += ' AND u.name=' + req.body.name;
+exports.reJudgeContest = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const list = await db.query('SELECT sid FROM submission WHERE cid=?', [req.body.cid]);
+    for (const s of list) {
+      await exports.setSubmission(s.sid, 2, 0, 0, 0, null, null);
+      pushSidIntoQueue(s.sid, true);
     }
-    if (req.body.pid) {
-      cntsql += ' AND p.pid=' + req.body.pid;
+    return ok(res, { message: 'ok', total: list.length });
+  }),
+];
+
+exports.cancelSubmission = [
+  requireRole(3),
+  handler(async (req, res) => {
+    const { sid } = req.body;
+    await db.query('UPDATE submission SET judgeResult=13,score=0 WHERE sid=?', [sid]);
+    const sub = await db.one('SELECT pid FROM submission WHERE sid=?', [sid]);
+    if (sub) {
+      exports.updateProblemSubmitInfo(sub.pid);
+      updateProblemStat(sub.pid);
     }
-    if (req.body.judgeRes !== null) {
-      cntsql += ' AND s.judgeResult=' + req.body.judgeRes;
-    }
-    if (req.body.score !== null) {
-      cntsql += ' AND s.score=' + req.body.score;
-    }
-    if (req.body.lang !== null) {
-      cntsql += ' AND s.lang=' + req.body.lang;
-    }
-    db.query(cntsql, (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      return res.status(200).send({
-        total: data[0].total,
-        data: list
-      });
-    });
-  });
-}
+    return ok(res, { message: 'ok' });
+  }),
+];
 
-const getCaseDetail = (sid) => {
-  return new Promise((resolve, reject) => {
-    db.query('SELECT * FROM submissionDetail WHERE sid=?', [sid], (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(data);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-
-exports.getSubmissionInfo = (req, res) => {
-  const sid = SqlString.escape(req.body.sid);
-  let sql = 'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.code,s.codeLength,s.submitTime,s.compileResult,s.caseResult,s.machine,s.lang,u.name,p.title,p.isPublic FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE sid=' + sid;
-  if (req.session.gid < 2) {
-    sql += ' and p.isPublic=1';
-  }
-  sql += ' AND s.cid=0';
-
-  db.query(sql, async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({
-      message: 'error'
-    });
-    else {
-      data[0].caseResult = JSON.parse(data[0].caseResult);
-      data[0].singleCaseResult = await getCaseDetail(req.body.sid);
-      data[0].singleCaseResult.sort((a, b) => a.caseId - b.caseId);
-      data[0].done = false;
-      if (data[0].caseResult) {
-        let subtaskInfo = {};
-        for (let i in data[0].caseResult) {
-          data[0].caseResult[i].index = parseInt(data[0].caseResult[i].index);
-          data[0].caseResult[i].res = judgeRes[data[0].caseResult[i].res];
-          data[0].caseResult[i].memory = kbFormat(data[0].caseResult[i].memory);
-          subtaskInfo[data[0].caseResult[i].index] = new Map();
-          subtaskInfo[data[0].caseResult[i].index]['info'] = data[0].caseResult[i];
-          subtaskInfo[data[0].caseResult[i].index]['cases'] = [];
-        }
-        for (let i in data[0].singleCaseResult) {
-          data[0].singleCaseResult[i].result = judgeRes[data[0].singleCaseResult[i].result];
-          data[0].singleCaseResult[i].memory = kbFormat(data[0].singleCaseResult[i].memory);
-          subtaskInfo[data[0].singleCaseResult[i].subtaskId]['cases'].push(data[0].singleCaseResult[i]);
-        }
-        data[0].subtaskInfo = subtaskInfo;
-        data[0].done = true;
-        delete data[0].caseResult;
-        delete data[0].singleCaseResult;
-      } else {
-        for (let i in data[0].singleCaseResult) {
-          data[0].singleCaseResult[i].result = judgeRes[data[0].singleCaseResult[i].result];
-          data[0].singleCaseResult[i].memory = kbFormat(data[0].singleCaseResult[i].memory);
-        }
-      }
-      data[0].memory = kbFormat(data[0].memory);
-      data[0].submitTime = Format(data[0].submitTime);
-      data[0].judgeResult = judgeRes[data[0].judgeResult];
-      return res.status(200).send({
-        data: data[0]
-      });
-    }
-  });
-}
-
-exports.reJudge = async (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-
-  await setSubmission(req.body.sid, 2, 0, 0, 0, null, null);
-
-  pushSidIntoQueue(req.body.sid, true);
-  await clearCase(req.body.sid);
-  res.status(200).send({
-    message: 'ok'
-  });
-}
-
-exports.reJudgeProblem = async (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-
-  db.query('SELECT sid FROM submission WHERE pid=?', [req.body.pid], (err, data) => {
-    for (let i in data) {
-      setSubmission(data[i].sid, 2, 0, 0, 0, null, null);
-      pushSidIntoQueue(data[i].sid, true)
-    }
-    updateProblemStat(req.body.pid);
-    updateProblemSubmitInfo(req.session.pid);
-    return res.status(200).send({
-      message: 'ok',
-      total: data.length
-    });
-  });
-}
-
-exports.reJudgeContest = async (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-
-  db.query('SELECT sid FROM submission WHERE cid=?', [req.body.cid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    for (let i in data) {
-      await setSubmission(data[i].sid, 2, 0, 0, 0, null, null);
-      pushSidIntoQueue(data[i].sid, true);
-    }
-    return res.status(200).send({
-      message: 'ok',
-      total: data.length
-    });
-  });
-}
-
-exports.cancelSubmission = (req, res) => {
-  if (req.session.gid < 3) return res.status(403).end('403 Forbidden');
-  db.query('UPDATE submission SET judgeResult=13,score=0 WHERE sid=?', [req.body.sid], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    else {
-      db.query('SELECT pid FROM submission WHERE sid=?', [req.body.sid], (err, data) => {
-        if (err) return res.status(202).send({ message: err });
-        else {
-          const pid = data[0].pid;
-          updateProblemSubmitInfo(pid);
-          updateProblemStat(pid);
-          return res.status(200).send({
-            message: 'ok',
-          });
-        }
-      })
-    }
-  })
-}
-
-exports.getLangs = async (req, res) => {
-  const data = await queryPromise("SELECT id,des,lang FROM languages");
-  const langList = data.reduce((L, i) => {
-    L[i.id] = i;
-    return L;
+exports.getLangs = handler(async (req, res) => {
+  const data = await db.query('SELECT id,des,lang FROM languages');
+  const langList = data.reduce((acc, i) => {
+    acc[i.id] = i;
+    return acc;
   }, {});
-  return res.status(200).send({
-    data: langList
-  });
-}
+  return ok(res, { data: langList });
+});

--- a/server/api/judgeWorker(Baltamatica).js
+++ b/server/api/judgeWorker(Baltamatica).js
@@ -101,12 +101,7 @@ const judgeCode = async (sid) => {
     if (pinfo.type === 1) {
       const spj = await getFile(`data/${pid}/checker.cpp`);
       if (!spj) {
-        await new Promise((resolve, reject) => {
-          db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', ['No checker.cpp found, please contact the problem publisher.', sid], (err, data) => {
-            if (err) reject(err);
-            else resolve(data);
-          });
-        });
+        await db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', ['No checker.cpp found, please contact the problem publisher.', sid]);
         await updateProblemSubmitInfo(pid);
         await updateProblemStat(pid);
         return;
@@ -148,12 +143,7 @@ const judgeCode = async (sid) => {
       });
       if (SPJcompileResult.exitStatus !== 0) {
         const error = 'SPJ Error\n' + SPJcompileResult.files.stderr;
-        await new Promise((resolve, reject) => {
-          db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', [error, sid], (err, data) => {
-            if (err) reject(err);
-            else resolve(data);
-          });
-        });
+        await db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', [error, sid]);
         await updateProblemSubmitInfo(pid);
         await updateProblemStat(pid);
         return;
@@ -375,12 +365,7 @@ const judgeCode = async (sid) => {
     if (acSub === totalSub) {
       finalRes = 4;
       totalScore = 100;
-      await new Promise((resolve, reject) => {
-        db.query('UPDATE problem SET acCnt=acCnt+1 WHERE pid=?', [pid], (err, data) => {
-          if (err) reject(err);
-          else resolve(data);
-        });
-      });
+      await db.query('UPDATE problem SET acCnt=acCnt+1 WHERE pid=?', [pid]);
     }
     await setSubmission(sid, finalRes, totalTime, maxMemory, totalScore, null, JSON.stringify(subtaskList), 'Ebola');
 

--- a/server/api/judgeWorker(C++).js
+++ b/server/api/judgeWorker(C++).js
@@ -77,12 +77,7 @@ const judgeCode = async (sid) => {
 
     if (compileResult.exitStatus !== 0) { // Compilation Error
       const error = `Compilation Error, Time: ${Math.floor(compileResult.time / 1000 / 1000)} ms, Memory: ${Math.floor(compileResult.memory / 1024)} KB\n` + compileResult.files.stderr;
-      await new Promise((resolve, reject) => {
-        db.query('UPDATE submission SET judgeResult=3,compileResult=? WHERE sid=?', [error, sid], (err, data) => {
-          if (err) reject(err);
-          else resolve(data);
-        });
-      });
+      await db.query('UPDATE submission SET judgeResult=3,compileResult=? WHERE sid=?', [error, sid]);
       await updateProblemSubmitInfo(pid);
       await updateProblemStat(pid);
       return;
@@ -100,12 +95,7 @@ const judgeCode = async (sid) => {
     if (pinfo.type === 1) {
       const spj = await getFile(`data/${pid}/checker.cpp`);
       if (!spj) {
-        await new Promise((resolve, reject) => {
-          db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', ['No checker.cpp found, please contact the problem publisher.', sid], (err, data) => {
-            if (err) reject(err);
-            else resolve(data);
-          });
-        });
+        await db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', ['No checker.cpp found, please contact the problem publisher.', sid]);
         await updateProblemSubmitInfo(pid);
         await updateProblemStat(pid);
         return;
@@ -147,12 +137,7 @@ const judgeCode = async (sid) => {
       });
       if (SPJcompileResult.exitStatus !== 0) {
         const error = 'SPJ Error\n' + SPJcompileResult.files.stderr;
-        await new Promise((resolve, reject) => {
-          db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', [error, sid], (err, data) => {
-            if (err) reject(err);
-            else resolve(data);
-          });
-        });
+        await db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', [error, sid]);
         await updateProblemSubmitInfo(pid);
         await updateProblemStat(pid);
         return;
@@ -392,12 +377,7 @@ const judgeCode = async (sid) => {
     if (acSub === totalSub) {
       finalRes = 4;
       totalScore = 100;
-      await new Promise((resolve, reject) => {
-        db.query('UPDATE problem SET acCnt=acCnt+1 WHERE pid=?', [pid], (err, data) => {
-          if (err) reject(err);
-          else resolve(data);
-        });
-      });
+      await db.query('UPDATE problem SET acCnt=acCnt+1 WHERE pid=?', [pid]);
     }
     await setSubmission(sid, finalRes, totalTime, maxMemory, totalScore, null, JSON.stringify(subtaskList), conf.JUDGE.NAME);
 

--- a/server/api/judgeWorker(Python3).js
+++ b/server/api/judgeWorker(Python3).js
@@ -77,12 +77,7 @@ const judgeCode = async (sid) => {
 
     if (compileResult.exitStatus !== 0) { // Compilation Error
       const error = `Compilation Error, Time: ${Math.floor(compileResult.time / 1000 / 1000)} ms, Memory: ${Math.floor(compileResult.memory / 1024)} KB\n` + compileResult.files.stderr + '\n' + compileResult.files.stdout;
-      await new Promise((resolve, reject) => {
-        db.query('UPDATE submission SET judgeResult=3,compileResult=? WHERE sid=?', [error, sid], (err, data) => {
-          if (err) reject(err);
-          else resolve(data);
-        });
-      });
+      await db.query('UPDATE submission SET judgeResult=3,compileResult=? WHERE sid=?', [error, sid]);
       await updateProblemSubmitInfo(pid);
       await updateProblemStat(pid);
       return;
@@ -100,12 +95,7 @@ const judgeCode = async (sid) => {
     if (pinfo.type === 1) {
       const spj = await getFile(`data/${pid}/checker.cpp`);
       if (!spj) {
-        await new Promise((resolve, reject) => {
-          db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', ['No checker.cpp found, please contact the problem publisher.', sid], (err, data) => {
-            if (err) reject(err);
-            else resolve(data);
-          });
-        });
+        await db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', ['No checker.cpp found, please contact the problem publisher.', sid]);
         await updateProblemSubmitInfo(pid);
         await updateProblemStat(pid);
         return;
@@ -147,12 +137,7 @@ const judgeCode = async (sid) => {
       });
       if (SPJcompileResult.exitStatus !== 0) {
         const error = 'SPJ Error\n' + SPJcompileResult.files.stderr;
-        await new Promise((resolve, reject) => {
-          db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', [error, sid], (err, data) => {
-            if (err) reject(err);
-            else resolve(data);
-          });
-        });
+        await db.query('UPDATE submission SET judgeResult=12,compileResult=? WHERE sid=?', [error, sid]);
         await updateProblemSubmitInfo(pid);
         await updateProblemStat(pid);
         return;
@@ -392,12 +377,7 @@ const judgeCode = async (sid) => {
     if (acSub === totalSub) {
       finalRes = 4;
       totalScore = 100;
-      await new Promise((resolve, reject) => {
-        db.query('UPDATE problem SET acCnt=acCnt+1 WHERE pid=?', [pid], (err, data) => {
-          if (err) reject(err);
-          else resolve(data);
-        });
-      });
+      await db.query('UPDATE problem SET acCnt=acCnt+1 WHERE pid=?', [pid]);
     }
     await setSubmission(sid, finalRes, totalTime, maxMemory, totalScore, null, JSON.stringify(subtaskList), conf.JUDGE.NAME);
 

--- a/server/api/problem.js
+++ b/server/api/problem.js
@@ -1,589 +1,396 @@
 require('express-zip');
-const SqlString = require('mysql/lib/protocol/SqlString');
-const db = require('../db/index');
-const { getFile, setFile } = require('../file');
 const fs = require('fs');
 const path = require('path');
-const { briefFormat, Format, bFormat, recordEvent, queryPromise, kbFormat } = require('../static');
-const judgeRes = ['Waiting',
-  'Pending',
-  'Rejudging',
-  'Compilation Error',
-  'Accepted',
-  'Wrong Answer',
-  'Time Limit Exceeded',
-  'Memory Limit Exceeded',
-  'Runtime Error',
-  'Segmentation Fault',
-  'Output Limit Exceeded',
-  'Dangerous System Call',
-  'System Error',
-  'Canceled',
-  'Skipped'];
+const db = require('../db');
+const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
+const { getFile, setFile } = require('../file');
+const { briefFormat, Format, bFormat, recordEvent, kbFormat } = require('../static');
+const { judgeRes, ptype } = require('../db/format');
 
-exports.createProblem = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  db.query('INSERT INTO problem(title,description,publisher,time,tags) VALUES (?,?,?,?,?)', ["请输入题目标题", "请输入题目描述", req.session.uid, new Date(), JSON.stringify(['请修改题目标签'])], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    if (data.affectedRows > 0) {
-      return res.status(200).send({
-        pid: data.insertId
-      })
-    } else {
-      return res.status(202).send({
-        message: 'error',
-      })
-    }
-  });
-}
+// ---- shared helpers ----
+const problemAuth = async (req, pid) => {
+  const row = await db.one('SELECT isPublic,publisher FROM problem WHERE pid=?', [pid]);
+  if (!row) return { view: false, manage: false };
+  return {
+    view: !!row.isPublic || req.session.gid > 1,
+    manage: row.publisher === req.session.uid || req.session.uid === 1,
+  };
+};
+exports.problemAuth = problemAuth;
 
-exports.updateProblem = async (req, res) => {
-  const pid = req.body.pid, info = req.body.info;
-  if (req.session.gid < 2 || !((await problemAuth(req, pid)).manage))
-    return res.status(403).end('403 Forbidden');
-  if (!info.title || !info.description || !info.timeLimit || !info.memoryLimit || !pid) {
-    return res.status(202).send({
-      message: '请确认信息完善'
-    });
-  }
-  if (req.session.gid < 3) {
-    if (info.timeLimit > 10000 || info.timeLimit < 0) {
-      return res.status(202).send({
-        message: '时间限制最大为10000ms'
-      });
-    }
-    if (info.memoryLimit > 512 || info.memoryLimit < 0) {
-      return res.status(202).send({
-        message: '空间限制最大为512MB'
-      });
-    }
-    if (info.tags?.length > 5) {
-      return res.status(202).send({
-        message: '题目标签最多设置5个'
-      });
-    }
-    for (t of info.tags)
-      if (t.length > 10)
-        return res.status(202).send({
-          message: '单个标签长度不能大于10'
-        });
-  }
-  if (info.isPublic !== false && info.isPublic !== true) {
-    return res.status(202).send({
-      message: 'isPublic格式错误'
-    });
-  }
-  if (info.level < 0 || info.level > 5) {
-    return res.status(202).send({
-      message: '难度评级格式错误'
-    });
-  }
-  info.isPublic = info.isPublic ? 1 : 0;
-  if (info.type === '传统文本比较') info.type = 0;
-  else if (info.type === 'Special Judge') info.type = 1;
-  db.query('UPDATE problem SET title=?,description=?,timeLimit=?,memoryLimit=?,isPublic=?,type=?,tags=?,level=?,lang=? WHERE pid=?', [info.title, info.description, info.timeLimit, info.memoryLimit, info.isPublic, info.type, JSON.stringify(info.tags), info.level, info.lang, pid], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    if (data.affectedRows > 0) {
-      return res.status(200).send({
-        message: 'success',
-      })
-    } else {
-      return res.status(202).send({
-        message: 'error',
-      })
-    }
-  });
-}
+const getProblemLang = async (pid) => {
+  const row = await db.one('SELECT lang FROM problem WHERE pid=?', [pid]);
+  return row ? row.lang : null;
+};
+exports.getProblemLang = getProblemLang;
 
-exports.getProblemList = (req, res) => {
-  let pageId = req.body.pageId,
-    pageSize = 20, filter = req.body.filter;
-  if (!pageId) pageId = 1;
-  pageId = SqlString.escape(pageId);
+const updateProblemStat = async (pid) => {
+  const stat = await db.query(
+    'SELECT score,judgeResult,COUNT(*) as cnt FROM submission WHERE pid=? GROUP BY score,judgeResult ORDER BY score,judgeResult',
+    [pid]
+  );
+  for (const i of stat) i.judgeResult = judgeRes[i.judgeResult];
+  await db.query('UPDATE problem SET stat=? WHERE pid=?', [JSON.stringify(stat), pid]);
+  return stat;
+};
+exports.updateProblemStat = updateProblemStat;
+
+// ---- handlers ----
+exports.createProblem = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const r = await db.query(
+      'INSERT INTO problem(title,description,publisher,time,tags) VALUES (?,?,?,?,?)',
+      ['请输入题目标题', '请输入题目描述', req.session.uid, new Date(), JSON.stringify(['请修改题目标签'])]
+    );
+    if (!r.affectedRows) return fail(res, 'error');
+    return ok(res, { pid: r.insertId });
+  }),
+];
+
+exports.updateProblem = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { pid } = req.body;
+    const info = req.body.info || {};
+    if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
+    if (!info.title || !info.description || !info.timeLimit || !info.memoryLimit || !pid)
+      return fail(res, '请确认信息完善');
+
+    if (req.session.gid < 3) {
+      if (info.timeLimit > 10000 || info.timeLimit < 0) return fail(res, '时间限制最大为10000ms');
+      if (info.memoryLimit > 512 || info.memoryLimit < 0) return fail(res, '空间限制最大为512MB');
+      if (info.tags?.length > 5) return fail(res, '题目标签最多设置5个');
+      for (const t of info.tags) {
+        if (t.length > 10) return fail(res, '单个标签长度不能大于10');
+      }
+    }
+    if (info.isPublic !== false && info.isPublic !== true) return fail(res, 'isPublic格式错误');
+    if (info.level < 0 || info.level > 5) return fail(res, '难度评级格式错误');
+
+    info.isPublic = info.isPublic ? 1 : 0;
+    if (info.type === '传统文本比较') info.type = 0;
+    else if (info.type === 'Special Judge') info.type = 1;
+
+    const r = await db.query(
+      'UPDATE problem SET title=?,description=?,timeLimit=?,memoryLimit=?,isPublic=?,type=?,tags=?,level=?,lang=? WHERE pid=?',
+      [info.title, info.description, info.timeLimit, info.memoryLimit, info.isPublic, info.type, JSON.stringify(info.tags), info.level, info.lang, pid]
+    );
+    if (!r.affectedRows) return fail(res, 'error');
+    return ok(res);
+  }),
+];
+
+exports.getProblemList = handler(async (req, res) => {
+  const { offset, limit } = paginate(req);
+  const filter = req.body.filter || {};
   if (filter.level === 6) filter.level = null;
 
-  let sql = "SELECT p.pid,p.title,p.acCnt,p.submitCnt,p.time,p.level,p.tags,p.publisher as publisherUid,u.`name` as publisher,p.isPublic FROM problem p INNER JOIN userInfo u ON u.uid = p.publisher " +
-    (req.session.gid > 1 ? "WHERE 1=1 " : "WHERE isPublic=1 ");
-  if (filter.publisherUid) {
-    filter.publisherUid = SqlString.escape(filter.publisherUid);
-    sql += `AND publisher=${filter.publisherUid} `;
-  }
-  if (filter.level !== null) {
-    filter.level = SqlString.escape(filter.level);
-    sql += `AND level=${filter.level} `;
-  }
-  if (filter.name) {
-    filter.name = SqlString.escape('%' + filter.name + '%');
-    sql += `AND title like ${filter.name} OR description like ${filter.name}`;
-  }
-  if (filter.tags?.length) {
-    sql += `AND JSON_CONTAINS(tags, '${JSON.stringify(filter.tags)}') `;
-  }
-  sql += " LIMIT " + (pageId - 1) * pageSize + "," + pageSize;
+  const visibility = req.session.gid > 1 ? '1=1' : 'isPublic=1';
+  const tagsParam = filter.tags?.length ? JSON.stringify(filter.tags) : null;
 
-  db.query(sql, (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    let list = data;
-    for (let i = 0; i < list.length; i++) {
-      list[i].time = briefFormat(list[i].time);
-      list[i].tags = JSON.parse(list[i].tags);
+  // 注意：原实现里 list 用 (title LIKE ? OR description LIKE ?)，而 count 只看 title — 这里统一用同一份条件以避免漂移
+  const cond = [
+    ['publisher=?', filter.publisherUid],
+    ['level=?', filter.level],
+    filter.name ? ['(title LIKE ? OR description LIKE ?)', `%${filter.name}%`, `%${filter.name}%`] : null,
+    ['JSON_CONTAINS(tags, ?)', tagsParam],
+  ];
+  const { where, params } = buildWhere(cond, visibility);
+
+  const list = await db.query(
+    'SELECT p.pid,p.title,p.acCnt,p.submitCnt,p.time,p.level,p.tags,p.publisher as publisherUid,u.name as publisher,p.isPublic ' +
+      'FROM problem p INNER JOIN userInfo u ON u.uid = p.publisher' +
+      `${where} LIMIT ?,?`,
+    [...params, offset, limit]
+  );
+  for (const r of list) {
+    r.time = briefFormat(r.time);
+    r.tags = JSON.parse(r.tags);
+  }
+
+  const cnt = await db.one(`SELECT COUNT(*) as total FROM problem${where}`, params);
+  return ok(res, { total: cnt.total, data: list });
+});
+
+exports.getProblemInfo = handler(async (req, res) => {
+  const { pid } = req.body;
+  const visibility = req.session.gid > 1 ? '' : ' AND isPublic=1';
+  const row = await db.one(
+    'SELECT p.pid,p.title,p.acCnt,p.submitCnt,p.description,p.time,p.timeLimit,p.memoryLimit,p.isPublic,p.type,p.tags,p.level,p.lang,p.publisher as publisherUid,u.`name` as publisher ' +
+      'FROM problem p INNER JOIN userInfo u ON u.uid = p.publisher WHERE pid=?' + visibility,
+    [pid]
+  );
+  if (!row) return fail(res, '无权限查看或未找到此题目');
+  row.type = ptype[row.type];
+  row.tags = JSON.parse(row.tags);
+  row.time = briefFormat(row.time);
+  return ok(res, { data: row });
+});
+
+exports.getProblemCasePreview = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { pid } = req.body;
+    const cfgRaw = await getFile(`./data/${pid}/config.json`);
+    const data = cfgRaw ? JSON.parse(cfgRaw) : null;
+
+    let spj = '';
+    if (fs.existsSync(`./data/${pid}/checker.cpp`)) {
+      spj = await getFile(`./data/${pid}/checker.cpp`);
     }
+    if (!data) return res.status(202).send({ data: [], spj, subtask: [] });
 
-    let totsql = "SELECT COUNT(*) as total FROM problem " + (req.session.gid > 1 ? "WHERE 1=1 " : "WHERE isPublic=1 ");
-    if (filter.publisherUid)
-      totsql += `AND publisher=${filter.publisherUid} `;
-    if (filter.level)
-      totsql += `AND level=${filter.level} `;
-    if (filter.name)
-      totsql += `AND title like ${filter.name} `;
-    if (filter.tags?.length)
-      totsql += `AND JSON_CONTAINS(tags, '${JSON.stringify(filter.tags)}') `;
-    db.query(totsql, (err, data) => {
-      if (err) return res.status(202).send({ message: err });
-      return res.status(200).send({
-        total: data[0].total,
-        data: list
-      });
-    });
-  });
-}
-
-const ptype = ['传统文本比较', 'Special Judge'];
-
-const problemAuth = async (req, pid) => {
-  const data = await queryPromise('SELECT isPublic,publisher FROM problem WHERE pid=?', [pid]);
-  if (!data.length)
-    return {
-      view: false,
-      manage: false
-    };
-  return {
-    view: (!!data[0].isPublic || req.session.gid > 1),
-    manage: (data[0].publisher === req.session.uid) || (req.session.uid === 1)
-  };
-}
-module.exports.problemAuth = problemAuth;
-
-const getProblemLang = (pid) => {
-  return new Promise((resolve, reject) => {
-    db.query('SELECT lang FROM problem WHERE pid=?', [pid], (err, data) => {
-      if (err) {
-        reject(err);
+    const cases = data.cases;
+    let previewList = [];
+    if (fs.existsSync(`./data/${pid}/preview.json`)) {
+      previewList = JSON.parse(await getFile(`./data/${pid}/preview.json`));
+    } else {
+      for (const i in cases) {
+        const inputFile = await getFile(`./data/${pid}/${cases[i].input}`);
+        const inputStat = fs.statSync(`./data/${pid}/${cases[i].input}`);
+        const outputFile = await getFile(`./data/${pid}/${cases[i].output}`);
+        const outputStat = fs.statSync(`./data/${pid}/${cases[i].output}`);
+        previewList[i] = {
+          index: cases[i].index,
+          inName: cases[i].input,
+          outName: cases[i].output,
+          subtaskId: cases[i].subtaskId,
+          input: {
+            content: inputFile.substring(0, 255) + (inputFile.length > 255 ? '......\n' : ''),
+            size: bFormat(inputStat.size),
+            create: Format(inputStat.birthtime),
+            modified: Format(inputStat.mtime),
+          },
+          output: {
+            content: outputFile.substring(0, 255) + (outputFile.length > 255 ? '......\n' : ''),
+            size: bFormat(outputStat.size),
+            create: Format(outputStat.birthtime),
+            modified: Format(outputStat.mtime),
+          },
+          edit: 0,
+        };
       }
-      resolve(data[0].lang);
-    })
-  }).catch(err => {
-    console.log(err);
-  });
-}
-module.exports.getProblemLang = getProblemLang;
-
-exports.getProblemInfo = (req, res) => {
-  const pid = req.body.pid;
-  let sql = "SELECT p.pid,p.title,p.acCnt,p.submitCnt,p.description,p.time,p.timeLimit,p.memoryLimit,p.isPublic,p.type,p.tags,p.level,p.lang,p.publisher as publisherUid,u.`name` as publisher FROM problem p INNER JOIN userInfo u ON u.uid = p.publisher WHERE pid=? "
-    + (req.session.gid > 1 ? "" : "AND isPublic=1");
-  db.query(sql, [pid], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length) return res.status(202).send({
-      message: '无权限查看或未找到此题目'
-    });
-    else {
-      data[0].type = ptype[data[0].type];
-      data[0].tags = JSON.parse(data[0].tags);
-      data[0].time = briefFormat(data[0].time);
-      return res.status(200).send({
-        data: data[0]
-      });
+      await setFile(`./data/${pid}/preview.json`, JSON.stringify(previewList));
     }
-  });
-}
+    return ok(res, { data: previewList, spj, subtask: data.subtask });
+  }),
+];
 
-exports.getProblemCasePreview = async (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  const pid = req.body.pid;
-  const data = JSON.parse(await (getFile(`./data/${pid}/config.json`)));
+exports.clearCase = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { pid } = req.body;
+    if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
+    const dir = path.join(__dirname, `../data/${pid}`);
+    recordEvent(req, 'problem.delAllCases', { pid });
+    if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true });
+    return ok(res);
+  }),
+];
 
-  let spj = '';
+exports.updateSubtaskId = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { pid, cases, subtask } = req.body;
+    if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
 
-  if (fs.existsSync(`./data/${pid}/checker.cpp`)) {
-    spj = await getFile(`./data/${pid}/checker.cpp`);
-  }
-  if (!data) return res.status(202).send({ data: [], spj: spj, subtask: [] });
-
-  const cases = data.cases;
-
-  let previewList = [];
-  if (fs.existsSync(`./data/${pid}/preview.json`)) {
-    previewList = JSON.parse(await getFile(`./data/${pid}/preview.json`));
-  }
-  else {
-    for (let i in cases) {
-      const inputFile = (await getFile(`./data/${pid}/${cases[i].input}`)),
-        inputStat = fs.statSync(`./data/${pid}/${cases[i].input}`);
-      const outputFile = (await getFile(`./data/${pid}/${cases[i].output}`)),
-        outputStat = fs.statSync(`./data/${pid}/${cases[i].output}`);
-
-      previewList[i] = {
-        index: cases[i].index,
-        inName: cases[i].input,
-        outName: cases[i].output,
-        subtaskId: cases[i].subtaskId,
-        input: {
-          content: inputFile.substring(0, 255) + (inputFile.length > 255 ? '......\n' : ''),
-          size: bFormat(inputStat.size),
-          create: Format(inputStat.birthtime),
-          modified: Format(inputStat.mtime)
-        },
-        output: {
-          content: outputFile.substring(0, 255) + (outputFile.length > 255 ? '......\n' : ''),
-          size: bFormat(outputStat.size),
-          create: Format(outputStat.birthtime),
-          modified: Format(outputStat.mtime)
-        },
-        edit: 0,
-      }
-    }
-    setFile(`./data/${pid}/preview.json`, JSON.stringify(previewList));
-  }
-
-  return res.status(200).send({
-    data: previewList,
-    spj: spj,
-    subtask: data.subtask
-  });
-}
-
-exports.clearCase = async (req, res) => {
-  const pid = req.body.pid;
-  if (req.session.gid < 2 || !((await problemAuth(req, pid)).manage))
-    return res.status(403).end('403 Forbidden');
-  const dir = path.join(__dirname, `../data/${req.body.pid}`);
-
-  recordEvent(req, 'problem.delAllCases', {
-    pid: pid
-  });
-
-  if (fs.existsSync(dir))
-    fs.rmSync(dir, {
-      recursive: true
-    });
-  return res.status(200).send({ message: 'success' });
-}
-
-exports.updateSubtaskId = async (req, res) => {
-  const pid = req.body.pid, cases = req.body.cases, subtask = req.body.subtask;
-  if (req.session.gid < 2 || !((await problemAuth(req, pid)).manage)) return res.status(403).end('403 Forbidden');
-  try {
-    let subtaskMap = new Map(), totalScore = 0;
+    const subtaskMap = new Map();
+    let totalScore = 0;
     for (let i = 0; i < subtask.length; i++) {
-      if (typeof subtask[i].index !== "number" || subtask[i].index !== i + 1)
-        return res.status(202).send({
-          message: `子任务 #${subtask[i].index} 编号非法或不连续`
-        });
-      if (!Number.isInteger(subtask[i].score) || subtask[i].score < 1 || subtask[i].score > 100)
-        return res.status(202).send({
-          message: `子任务 #${subtask[i].index} 分数应为[1,100]之间的整数`
-        });
-      if (subtask[i].option !== 0 && subtask[i].option !== 1)
-        return res.status(202).send({
-          message: `子任务 #${subtask[i].index} 记分方式非法`
-        });
-      if (subtaskMap.has(subtask[i].index))
-        return res.status(202).send({
-          message: `子任务 #${subtask[i].index} 编号重复`
-        });
-      if (subtask[i].index < 1 || subtask[i].index > 100)
-        return res.status(202).send({
-          message: `子任务 #${subtask[i].index} 应在[1,100]之间`
-        });
-      if (!subtask[i].option && subtask[i].skip)
-        return res.status(202).send({
-          message: `测试点等分的子任务 #${subtask[i].index} 无法设置遇TLE止测`
-        });
-      if (!subtask[i].option && subtask[i]?.dependencies?.length)
-        return res.status(202).send({
-          message: `测试点等分的子任务 #${subtask[i].index} 无法设置子任务依赖`
-        });
-      for (let id of subtask[i].dependencies) {
-        if (id >= subtask[i].index) {
-          return res.status(202).send({
-            message: `子任务 #${subtask[i].index} 依赖了 id>=${subtask[i].index} 的子任务`
-          });
-        }
+      const s = subtask[i];
+      if (typeof s.index !== 'number' || s.index !== i + 1)
+        return fail(res, `子任务 #${s.index} 编号非法或不连续`);
+      if (!Number.isInteger(s.score) || s.score < 1 || s.score > 100)
+        return fail(res, `子任务 #${s.index} 分数应为[1,100]之间的整数`);
+      if (s.option !== 0 && s.option !== 1) return fail(res, `子任务 #${s.index} 记分方式非法`);
+      if (subtaskMap.has(s.index)) return fail(res, `子任务 #${s.index} 编号重复`);
+      if (s.index < 1 || s.index > 100) return fail(res, `子任务 #${s.index} 应在[1,100]之间`);
+      if (!s.option && s.skip) return fail(res, `测试点等分的子任务 #${s.index} 无法设置遇TLE止测`);
+      if (!s.option && s.dependencies?.length)
+        return fail(res, `测试点等分的子任务 #${s.index} 无法设置子任务依赖`);
+      for (const id of s.dependencies) {
+        if (id >= s.index) return fail(res, `子任务 #${s.index} 依赖了 id>=${s.index} 的子任务`);
       }
-      subtaskMap.set(subtask[i].index, subtask[i].score);
-      totalScore += subtask[i].score;
+      subtaskMap.set(s.index, s.score);
+      totalScore += s.score;
     }
-    if (totalScore !== 100)
-      return res.status(202).send({
-        message: `子任务分数之和应等于100分`
+    if (totalScore !== 100) return fail(res, '子任务分数之和应等于100分');
+
+    const newCases = [];
+    const subtaskVis = new Map();
+    for (const i in cases) {
+      const c = cases[i];
+      if (!fs.existsSync(`./data/${pid}/${c.inName}`) || !fs.existsSync(`./data/${pid}/${c.outName}`))
+        return fail(res, `找不到数据点 ${c.inName}/${c.outName}`);
+      if (!subtaskMap.has(Number(c.subtaskId)))
+        return fail(res, `测试点 #${c.index} 所属子任务 #${Number(c.subtaskId)} 未定义`);
+      newCases.push({
+        index: Number(i) + 1,
+        input: c.inName,
+        output: c.outName,
+        subtaskId: Number(c.subtaskId),
       });
-    let newCases = [], subtaskVis = new Map();
-    for (i in cases) {
-      if (fs.existsSync(`./data/${pid}/${cases[i].inName}`) && fs.existsSync(`./data/${pid}/${cases[i].outName}`)) {
-        if (!subtaskMap.has(Number(cases[i].subtaskId))) {
-          return res.status(202).send({
-            message: `测试点 #${cases[i].index} 所属子任务 #${Number(cases[i].subtaskId)} 未定义`
-          });
-        }
-        newCases.push({
-          index: Number(i) + 1,
-          input: cases[i].inName,
-          output: cases[i].outName,
-          subtaskId: Number(cases[i].subtaskId)
-        });
-        subtaskVis.set(Number(cases[i].subtaskId), true);
-      } else {
-        return res.status(202).send({
-          message: `找不到数据点 ${cases[i].inName}/${cases[i].outName}`
-        });
-      }
+      subtaskVis.set(Number(c.subtaskId), true);
     }
-    for (let i in subtask) {
-      subtaskVis[subtask[i].index];
-      if (!subtaskVis.has(subtask[i].index))
-        return res.status(202).send({
-          message: `子任务 #${subtask[i].index} 中没有测试点`
-        });
+    for (const s of subtask) {
+      if (!subtaskVis.has(s.index)) return fail(res, `子任务 #${s.index} 中没有测试点`);
     }
-    newCases.sort((a, b) => {
-      return a.index - b.index;
-    });
-    await setFile(`./data/${pid}/config.json`, JSON.stringify({ cases: newCases, subtask: subtask }));
-    recordEvent(req, 'problem.updateConfig', {
-      pid: pid
-    });
+    newCases.sort((a, b) => a.index - b.index);
+
+    await setFile(`./data/${pid}/config.json`, JSON.stringify({ cases: newCases, subtask }));
+    recordEvent(req, 'problem.updateConfig', { pid });
     if (fs.existsSync(`./data/${pid}/preview.json`)) {
       fs.rmSync(`./data/${pid}/preview.json`);
     }
-    return res.status(200).send({ message: 'success' });
-  } catch (err) {
-    return res.status(202).send({ message: String(err) });
-  }
-}
+    return ok(res);
+  }),
+];
 
-exports.getCase = async (req, res) => {
-  const pid = req.body.pid, caseInfo = req.body.caseInfo;
-  if (req.session.gid < 2 || !((await problemAuth(req, pid)).manage))
-    return res.status(403).end('403 Forbidden');
-  if (!fs.existsSync(`./data/${pid}/${caseInfo.inName}`) ||
-    !fs.existsSync(`./data/${pid}/${caseInfo.outName}`)) {
-    return res.status(202).send({ message: "未找到测试点" });
-  }
-  const inputFile = (await getFile(`./data/${pid}/${caseInfo.inName}`)),
-    inputStat = fs.statSync(`./data/${pid}/${caseInfo.inName}`);
-  const outputFile = (await getFile(`./data/${pid}/${caseInfo.outName}`)),
-    outputStat = fs.statSync(`./data/${pid}/${caseInfo.outName}`);
-  if (inputStat.size + outputStat.size > 5 * 1024 * 1024)
-    return res.status(202).send({
-      message: `超过编辑大小限制 5MB`
-    });
-  return res.status(200).send({
-    input: inputFile,
-    output: outputFile
-  });
-}
+exports.getCase = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { pid, caseInfo } = req.body;
+    if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
+    if (!fs.existsSync(`./data/${pid}/${caseInfo.inName}`) || !fs.existsSync(`./data/${pid}/${caseInfo.outName}`))
+      return fail(res, '未找到测试点');
 
-exports.updateCase = async (req, res) => {
-  const pid = req.body.pid, caseInfo = req.body.caseInfo;
-  if (req.session.gid < 2 || !((await problemAuth(req, pid)).manage))
-    return res.status(403).end('403 Forbidden');
-  if (!fs.existsSync(`./data/${pid}/${caseInfo.inName}`) ||
-    !fs.existsSync(`./data/${pid}/${caseInfo.outName}`)) {
-    return res.status(202).send({ message: "未找到测试点" });
-  }
-  try {
+    const inputFile = await getFile(`./data/${pid}/${caseInfo.inName}`);
+    const inputStat = fs.statSync(`./data/${pid}/${caseInfo.inName}`);
+    const outputFile = await getFile(`./data/${pid}/${caseInfo.outName}`);
+    const outputStat = fs.statSync(`./data/${pid}/${caseInfo.outName}`);
+    if (inputStat.size + outputStat.size > 5 * 1024 * 1024) return fail(res, '超过编辑大小限制 5MB');
+    return ok(res, { input: inputFile, output: outputFile });
+  }),
+];
+
+exports.updateCase = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { pid, caseInfo } = req.body;
+    if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
+    if (!fs.existsSync(`./data/${pid}/${caseInfo.inName}`) || !fs.existsSync(`./data/${pid}/${caseInfo.outName}`))
+      return fail(res, '未找到测试点');
+
     await setFile(`./data/${pid}/${caseInfo.inName}`, caseInfo.input.content);
     await setFile(`./data/${pid}/${caseInfo.outName}`, caseInfo.output.content);
-    recordEvent(req, 'problem.updateCase', {
-      pid: pid,
-      index: caseInfo.index
-    });
+    recordEvent(req, 'problem.updateCase', { pid, index: caseInfo.index });
     if (fs.existsSync(`./data/${pid}/preview.json`)) {
       fs.rmSync(`./data/${pid}/preview.json`);
     }
-    return res.status(200).send({
+    return ok(res, {
       inputM: Format(fs.statSync(`./data/${pid}/${caseInfo.inName}`).mtime),
       outputM: Format(fs.statSync(`./data/${pid}/${caseInfo.outName}`).mtime),
-      message: 'ok'
+      message: 'ok',
     });
-  } catch (err) {
-    return res.status(202).send({ message: String(err) });
-  }
-}
+  }),
+];
 
-exports.downloadCase = (req, res) => {
-  if (req.session.gid < 2) return res.status(403).end('403 Forbidden');
-  const pid = req.query.pid, index = req.query.index;
-  db.query('SELECT * FROM problem WHERE pid=?', [pid], async (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    if (!data.length || !fs.existsSync(`./data/${pid}/config.json`))
-      return res.status(202).send({ message: 'Not Found Error' });
-    if (req.session.uid !== 1 && data[0].publisher !== req.session.uid) {
-      return res.status(202).send({ message: '你只能下载自己题目的测试点' });
-    }
-    const cases = JSON.parse(await (getFile(`./data/${pid}/config.json`))).cases;
-    let files = [];
-    for (let i in cases) {
-      if (typeof index === 'undefined' || cases[i].index === parseInt(index)) {
-        files.push({
-          path: `./data/${pid}/${cases[i].input}`,
-          name: cases[i].input
-        });
-        files.push({
-          path: `./data/${pid}/${cases[i].output}`,
-          name: cases[i].output
-        });
+exports.downloadCase = [
+  requireRole(2),
+  handler(async (req, res) => {
+    const { pid, index } = req.query;
+    const problem = await db.one('SELECT publisher FROM problem WHERE pid=?', [pid]);
+    if (!problem || !fs.existsSync(`./data/${pid}/config.json`)) return fail(res, 'Not Found Error');
+    if (req.session.uid !== 1 && problem.publisher !== req.session.uid)
+      return fail(res, '你只能下载自己题目的测试点');
+
+    const { cases } = JSON.parse(await getFile(`./data/${pid}/config.json`));
+    const files = [];
+    for (const i in cases) {
+      if (typeof index === 'undefined' || cases[i].index === parseInt(index, 10)) {
+        files.push({ path: `./data/${pid}/${cases[i].input}`, name: cases[i].input });
+        files.push({ path: `./data/${pid}/${cases[i].output}`, name: cases[i].output });
       }
     }
     if (typeof index === 'undefined') {
-      files.push({
-        path: `./data/${pid}/config.json`,
-        name: 'config.json'
-      });
-      if (fs.existsSync(`./data/${pid}/checker.cpp`)) {
-        files.push({
-          path: `./data/${pid}/checker.cpp`,
-          name: 'checker.cpp'
-        });
-      }
-      recordEvent(req, 'problem.downloadCase', {
-        pid: pid
-      });
+      files.push({ path: `./data/${pid}/config.json`, name: 'config.json' });
+      if (fs.existsSync(`./data/${pid}/checker.cpp`))
+        files.push({ path: `./data/${pid}/checker.cpp`, name: 'checker.cpp' });
+      recordEvent(req, 'problem.downloadCase', { pid });
     } else {
-      recordEvent(req, 'problem.downloadCase', {
-        pid: pid,
-        index: index
-      });
+      recordEvent(req, 'problem.downloadCase', { pid, index });
     }
     const fileName = (index ? `nywoj_Testdata_#${pid}_case#${index}` : `nywoj_Testdata_#${pid}`) + '.zip';
     return res.zip(files, fileName);
-  });
-}
+  }),
+];
 
-exports.getProblemTags = (req, res) => {
-  db.query(`SELECT DISTINCT JSON_UNQUOTE(value) AS tag
-          FROM problem,
-          JSON_TABLE(tags, '$[*]' COLUMNS (value JSON PATH '$')) AS jt
-          WHERE JSON_VALID(tags);`, [], (err, data) => {
-    if (err) return res.status(202).send({ message: err });
-    const tags = data.map(data => data.tag);
-    return res.status(200).send(tags);
-  })
-}
+exports.getProblemTags = handler(async (req, res) => {
+  const data = await db.query(
+    `SELECT DISTINCT JSON_UNQUOTE(value) AS tag
+       FROM problem,
+       JSON_TABLE(tags, '$[*]' COLUMNS (value JSON PATH '$')) AS jt
+      WHERE JSON_VALID(tags)`
+  );
+  return res.status(200).send(data.map((r) => r.tag));
+});
 
-exports.getProblemPublishers = async (req, res) => {
-  try {
-    const data = await queryPromise('SELECT DISTINCT(p.publisher),u.name FROM problem p INNER JOIN userInfo u WHERE p.publisher=u.uid');
-    return res.status(200).send(data);
-  } catch (err) {
-    return res.status(202).send({ message: err });
-  }
-}
+exports.getProblemPublishers = handler(async (req, res) => {
+  const data = await db.query(
+    'SELECT DISTINCT(p.publisher),u.name FROM problem p INNER JOIN userInfo u WHERE p.publisher=u.uid'
+  );
+  return res.status(200).send(data);
+});
 
-const updateProblemStat = async (pid) => {
-  let stat = await queryPromise('SELECT score,judgeResult,COUNT(*) as cnt FROM submission WHERE pid=? GROUP BY score,judgeResult ORDER BY score,judgeResult', [pid]);
-  for (let i of stat)
-    i.judgeResult = judgeRes[i.judgeResult];
-  await queryPromise('UPDATE problem SET stat=? WHERE pid=?', [JSON.stringify(stat), pid]);
-  return stat;
-}
-module.exports.updateProblemStat = updateProblemStat;
+exports.getProblemStat = handler(async (req, res) => {
+  const { pid } = req.body;
+  if (!pid) return fail(res, 'expect pid');
+  if (!(await problemAuth(req, pid)).view) return fail(res, '权限不足');
 
-exports.getProblemStat = async (req, res) => {
-  let pid = req.body.pid;
-  if (!pid) return res.status(202).send({ message: 'expect pid' });
-  if (!((await problemAuth(req, pid)).view)) {
-    return res.status(202).send({
-      message: '权限不足'
-    });
-  }
-  try {
-    let data = await queryPromise('SELECT stat FROM problem WHERE pid=?', [pid]);
-    data = data[0];
-    if (!data.stat)
-      return res.status(200).send({ stat: await updateProblemStat(pid) });
-    else
-      return res.status(200).send({ stat: JSON.parse(data.stat) });
-  } catch (err) {
-    return res.status(202).send({ message: err });
-  }
-}
+  const row = await db.one('SELECT stat FROM problem WHERE pid=?', [pid]);
+  if (!row || !row.stat) return ok(res, { stat: await updateProblemStat(pid) });
+  return ok(res, { stat: JSON.parse(row.stat) });
+});
 
-exports.getProblemFastestSubmission = async (req, res) => {
-  let pid = req.body.pid;
-  if (!pid) return res.status(202).send({ message: 'expect pid' });
-  if (!((await problemAuth(req, pid)).view)) {
-    return res.status(202).send({
-      message: '权限不足'
-    });
-  }
-  try {
-    let sql = "SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.cid,s.machine,s.lang,u.name,p.title,p.isPublic FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE p.pid=? AND score=100 ORDER BY s.time LIMIT 10"
-    let data = await queryPromise(sql, [pid]);
-    for (let i of data) i.memory = kbFormat(i.memory);
-    return res.status(200).send({ data: data });
-  } catch (err) {
-    return res.status(202).send({ message: err });
-  }
-}
+exports.getProblemFastestSubmission = handler(async (req, res) => {
+  const { pid } = req.body;
+  if (!pid) return fail(res, 'expect pid');
+  if (!(await problemAuth(req, pid)).view) return fail(res, '权限不足');
 
-exports.bindPaste2Problem = async (req, res) => {
-  let pid = req.body.pid, mark = req.body.mark;
-  if (!pid || !mark) return res.status(202).send({ message: 'expect pid && mark' });
-  if (req.session.gid < 2) {
-    return res.status(202).send({
-      message: '权限不足'
-    });
-  }
-  try {
-    let paste = await queryPromise('SELECT COUNT(*) as cnt FROM pastes WHERE mark=?', [mark]);
-    if (!paste[0].cnt)
-      return res.status(202).send({ message: `未找到mark为${mark}的剪贴板` });
-    await queryPromise('INSERT INTO problemSolution(pid,mark) VALUES (?,?)', [pid, mark]);
-    return res.status(200).send({ message: 'success' })
-  } catch (err) {
-    return res.status(202).send({ message: err });
-  }
-}
+  const data = await db.query(
+    'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.codeLength,s.submitTime,s.cid,s.machine,s.lang,u.name,p.title,p.isPublic ' +
+      'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid ' +
+      'WHERE p.pid=? AND score=100 ORDER BY s.time LIMIT 10',
+    [pid]
+  );
+  for (const r of data) r.memory = kbFormat(r.memory);
+  return ok(res, { data });
+});
 
-exports.getProblemSol = async (req, res) => {
-  let pid = req.body.pid;
-  if (!pid) return res.status(202).send({ message: 'expect pid' });
-  if (!((await problemAuth(req, pid)).view)) {
-    return res.status(202).send({
-      message: '权限不足'
-    });
-  }
-  try {
-    let sql = "SELECT s.id,s.mark,p.uid,p.title,u.name,p.time,p.isPublic FROM problemSolution s INNER JOIN pastes p ON s.mark=p.mark INNER JOIN userInfo u ON p.uid=u.uid WHERE s.show=1 AND s.pid=? ORDER BY p.time"
-    let data = await queryPromise(sql, [pid]);
-    for (let i of data) i.time = briefFormat(i.time);
-    return res.status(200).send({ data: data });
-  } catch (err) {
-    return res.status(202).send({ message: err });
-  }
-}
+exports.bindPaste2Problem = handler(async (req, res) => {
+  const { pid, mark } = req.body;
+  if (!pid || !mark) return fail(res, 'expect pid && mark');
+  if (req.session.gid < 2) return fail(res, '权限不足');
 
-exports.unbindSol = async (req, res) => {
-  let id = req.body.id;
-  if (req.session.gid < 2) {
-    return res.status(202).send({
-      message: '权限不足'
-    });
-  }
-  try {
-    await queryPromise('UPDATE problemSolution SET `show`=0 WHERE id=?', [id]);
-    return res.status(200).send({ message: 'success' });
-  } catch (err) {
-    return res.status(202).send({ message: err });
-  }
-}
+  const exists = await db.exists('SELECT 1 FROM pastes WHERE mark=?', [mark]);
+  if (!exists) return fail(res, `未找到mark为${mark}的剪贴板`);
+  await db.query('INSERT INTO problemSolution(pid,mark) VALUES (?,?)', [pid, mark]);
+  return ok(res);
+});
 
-exports.getProblemAuth = async (req, res) => {
-  return res.status(200).send({ data: await problemAuth(req, req.body.pid) });
-}
+exports.getProblemSol = handler(async (req, res) => {
+  const { pid } = req.body;
+  if (!pid) return fail(res, 'expect pid');
+  if (!(await problemAuth(req, pid)).view) return fail(res, '权限不足');
+
+  const data = await db.query(
+    'SELECT s.id,s.mark,p.uid,p.title,u.name,p.time,p.isPublic ' +
+      'FROM problemSolution s INNER JOIN pastes p ON s.mark=p.mark INNER JOIN userInfo u ON p.uid=u.uid ' +
+      'WHERE s.show=1 AND s.pid=? ORDER BY p.time',
+    [pid]
+  );
+  for (const r of data) r.time = briefFormat(r.time);
+  return ok(res, { data });
+});
+
+exports.unbindSol = handler(async (req, res) => {
+  const { id } = req.body;
+  if (req.session.gid < 2) return fail(res, '权限不足');
+  await db.query('UPDATE problemSolution SET `show`=0 WHERE id=?', [id]);
+  return ok(res);
+});
+
+exports.getProblemAuth = handler(async (req, res) => {
+  return ok(res, { data: await problemAuth(req, req.body.pid) });
+});

--- a/server/api/rabbit.js
+++ b/server/api/rabbit.js
@@ -1,138 +1,102 @@
-const db = require('../db/index');
+const db = require('../db');
+const { handler, fail, ok, paginate } = require('../db/util');
 const { Format, ip2loc } = require('../static');
+
 let dayClick = {};
-const SqlString = require('mysql/lib/protocol/SqlString');
 
-exports.all = (req, res) => {
-  let sql = 'SELECT clickList.id,clickList.time,clickList.uid,userInfo.name,clickList.ip,clickList.iploc,userInfo.clickCnt,userInfo.gid FROM clickList INNER JOIN userInfo ON userInfo.uid = clickList.uid ORDER BY clickList.id DESC LIMIT 20';
-  db.query(sql, (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    for (let i = 0; i < data.length; i++) data[i].time = Format(data[i].time);
-    return res.status(200).send({
-      data: data
-    });
-  })
-}
+exports.all = handler(async (req, res) => {
+  const list = await db.query(
+    'SELECT clickList.id,clickList.time,clickList.uid,userInfo.name,clickList.ip,clickList.iploc,userInfo.clickCnt,userInfo.gid ' +
+      'FROM clickList INNER JOIN userInfo ON userInfo.uid = clickList.uid ' +
+      'ORDER BY clickList.id DESC LIMIT 20'
+  );
+  for (const r of list) r.time = Format(r.time);
+  return ok(res, { data: list });
+});
 
-exports.add = (req, res) => {
-  const ip = req.session.ip, uid = req.session.uid;
+exports.add = handler(async (req, res) => {
+  const { ip, uid } = req.session;
 
   if (!dayClick.lastClick || new Date().getDate() !== dayClick.lastClick.getDate()) {
     dayClick = {};
   }
   if (!dayClick[uid]) dayClick[uid] = 0;
-  const cnt = dayClick[uid];
-
-  if (cnt >= 1000000) {
-    return res.status(202).send({
-      message: "请明天再试"
-    })
-  }
+  if (dayClick[uid] >= 1000000) return fail(res, '请明天再试');
 
   const iploc = ip2loc(ip);
-  db.query('INSERT INTO clickList(uid,time,ip,iploc) values (?,?,?,?)', [uid, new Date(), ip, iploc], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    if (data.affectedRows > 0) {
-      let sql = "INSERT INTO rabbitstat (uid, click, date) VALUES (?, 1, ?) ON DUPLICATE KEY UPDATE click = click + 1";
-      db.query(sql, [uid, new Date()], (err2, data2) => {
-        if (err2) return res.status(202).send({
-          message: err2
-        });
-        dayClick[uid]++;
-        dayClick.lastClick = new Date();
-        db.query("UPDATE userInfo SET clickCnt=clickCnt+1 WHERE uid=?", [uid]);
-        return res.status(200).send({
-          message: 'success',
-        });
-      });
-    } else {
-      return res.status(202).send({
-        message: 'error',
-      })
-    }
-  });
-}
+  const r = await db.query(
+    'INSERT INTO clickList(uid,time,ip,iploc) values (?,?,?,?)',
+    [uid, new Date(), ip, iploc]
+  );
+  if (!r.affectedRows) return fail(res, 'error');
 
-exports.getClickCnt = (req, res) => {
-  let uid = req.session.uid;
-  if (req.body.uid) uid = req.body.uid;
-  let sql = 'SELECT clickCnt FROM userInfo WHERE uid=?';
-  db.query(sql, [uid], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    return res.status(200).send({ clickCnt: data[0].clickCnt });
-  })
-}
+  await db.query(
+    'INSERT INTO rabbitstat (uid, click, date) VALUES (?, 1, ?) ON DUPLICATE KEY UPDATE click = click + 1',
+    [uid, new Date()]
+  );
+  await db.query('UPDATE userInfo SET clickCnt=clickCnt+1 WHERE uid=?', [uid]);
 
-exports.getRankInfo = (req, res) => {
-  let pageId = req.body.pageId,
-    pageSize = 20;
-  if (!pageId) pageId = 1;
-  pageId = SqlString.escape(pageId);
-  let sql = 'SELECT uid,name,clickCnt,motto,gid,qq FROM userInfo GROUP BY uid ORDER BY clickCnt DESC LIMIT ' + (pageId - 1) * pageSize + ',' + pageSize;
-  db.query(sql, (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    for (let i = 0; i < data.length; i++) {
-      if (String(data[i].motto).length > 50)
-        data[i].motto = data[i].motto.substring(0, 50) + '...';
-      data[i].rk = (pageId - 1) * pageSize + i + 1;
-      data[i].avatar =
-        data[i].qq ? `https://q1.qlogo.cn/g?b=qq&nk=${data[i].qq}&s=3`
-          : '/default-avatar.svg';
+  dayClick[uid]++;
+  dayClick.lastClick = new Date();
+  return ok(res);
+});
 
-    }
-    db.query("SELECT COUNT(*) as total FROM userInfo", (err2, data2) => {
-      if (err2) return res.status(202).send({ message: err2 });
-      return res.status(200).send({
-        total: data2[0].total,
-        data: data
-      });
-    });
-  })
-}
+exports.getClickCnt = handler(async (req, res) => {
+  const uid = req.body.uid || req.session.uid;
+  const row = await db.one('SELECT clickCnt FROM userInfo WHERE uid=?', [uid]);
+  return ok(res, { clickCnt: row ? row.clickCnt : 0 });
+});
 
-exports.getClickData = (req, res) => {
-  let quid = req.body.uid, day = req.body.day;
-  if (typeof day === 'undefined' || day > 100)
-    day = 6;
+exports.getRankInfo = handler(async (req, res) => {
+  const { pageId, offset, limit } = paginate(req);
+  const list = await db.query(
+    'SELECT uid,name,clickCnt,motto,gid,qq FROM userInfo GROUP BY uid ORDER BY clickCnt DESC LIMIT ?,?',
+    [offset, limit]
+  );
+  for (let i = 0; i < list.length; i++) {
+    if (String(list[i].motto).length > 50)
+      list[i].motto = list[i].motto.substring(0, 50) + '...';
+    list[i].rk = offset + i + 1;
+    list[i].avatar = list[i].qq
+      ? `https://q1.qlogo.cn/g?b=qq&nk=${list[i].qq}&s=3`
+      : '/default-avatar.svg';
+  }
+  const cnt = await db.one('SELECT COUNT(*) as total FROM userInfo');
+  return ok(res, { total: cnt.total, data: list });
+});
+
+exports.getClickData = handler(async (req, res) => {
+  const quid = req.body.uid;
+  let day = req.body.day;
+  if (typeof day === 'undefined' || day > 100) day = 6;
   else day = day - 1;
-  const sql = `
-  SELECT 
+
+  const params = [day];
+  let userClause = '';
+  if (typeof quid !== 'undefined') {
+    userClause = 'AND uid=? ';
+    params.push(quid);
+  }
+  const sql =
+    'SELECT date, SUM(click) AS clickCnt, COUNT(DISTINCT uid) AS userCnt ' +
+    'FROM rabbitstat ' +
+    'WHERE date >= DATE_SUB(CURDATE(), INTERVAL ? DAY) ' +
+    userClause +
+    'GROUP BY date ORDER BY date';
+  const data = await db.query(sql, params);
+
+  const mp = {};
+  const now = new Date();
+  for (let i = day; i >= 0; i--) {
+    mp[Format(new Date(now.getTime() - 1000 * 3600 * 24 * i)).substring(5, 10)] = [0, 0];
+  }
+  for (const r of data) {
+    mp[Format(r.date).substring(5, 10)] = [r.clickCnt, r.userCnt];
+  }
+  const result = Object.keys(mp).map((date) => ({
     date,
-    SUM(click) AS clickCnt,
-    COUNT(DISTINCT uid) AS userCnt
-  FROM rabbitstat
-  WHERE date >= DATE_SUB(CURDATE(), INTERVAL ? DAY) ` +
-    (typeof quid !== 'undefined' ? `AND uid = ${SqlString.escape(quid)} ` : "") +
-    `GROUP BY date
-  ORDER BY date;
-  `;
-  db.query(sql, [day], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    let mp = [], now = new Date();
-    for (let i = day; i >= 0; i--)
-      mp[Format(new Date(now.getTime() - 1000 * 3600 * 24 * i)).substring(5, 10)] = [0, 0];
-    for (let i = 0; i < data.length; i++)
-      mp[Format(data[i].date).substring(5, 10)] = [data[i].clickCnt, data[i].userCnt];
-    let result = []
-    for (let key in mp) {
-      result.push({
-        date: key,
-        clickCnt: mp[key][0],
-        userCnt: mp[key][1]
-      })
-    }
-    return res.status(200).send({
-      data: result
-    });
-  })
-}
+    clickCnt: mp[date][0],
+    userCnt: mp[date][1],
+  }));
+  return ok(res, { data: result });
+});

--- a/server/api/user.js
+++ b/server/api/user.js
@@ -1,486 +1,292 @@
-const db = require('../db/index');
 const bcrypt = require('bcryptjs');
-const axios = require('axios');
 const mail = require('nodemailer');
+const db = require('../db');
+const { handler, fail, ok, paginate } = require('../db/util');
 const { Format, ip2loc, msFormat, recordEvent, eventList, eventExp, briefFormat } = require('../static');
 const config = require('../config.json');
 
-exports.reg = async (req, res) => {
-  const name = req.body.name;
-  const pwd = req.body.pwd;
-  const rePwd = req.body.rePwd;
-  const email = req.session.verifiedEmail.email;
-  if (!email) {
-    return res.status(202).send({
-      message: "请先验证邮箱"
-    })
-  }
-  const time = new Date().getTime();
-  if (time > req.session.verifiedEmail.expire) {
-    return res.status(202).send({ message: "操作超时，请重新绑定邮箱" });
-  }
-  if (!name || !pwd || !rePwd) {
-    return res.status(202).send({
-      message: "请确认信息完善"
-    })
-  }
-  if (name.length < 3 || name.length > 15) {
-    return res.status(202).send({
-      message: "用户名长度应在3~15之间"
-    })
-  }
-  for (let i = 0; i < name.length; i++) {
-    if (!((name[i] >= 'A' && name[i] <= 'Z') || (name[i] >= 'a' && name[i] <= 'z') || (name[i] >= '0' && name[i] <= '9'))) {
-      return res.status(202).send({
-        message: "用户名应只包含字母或数字"
-      })
-    }
-  }
-  if (pwd.length > 31 || pwd.length < 6) {
-    return res.status(202).send({
-      message: "密码长度应在6~31之间"
-    })
-  }
-  if (pwd !== rePwd) {
-    return res.status(202).send({
-      message: "两次输入的密码不一致"
-    })
-  }
-  // let ok = true;
-  // await axios.get('https://v.api.aa1.cn/api/api-mgc/index.php', {
-  //     params: {
-  //         msg: name,
-  //     }
-  // }).then(res => {
-  //     if (res.data.num === '1')
-  //         ok = false;
-  // });
-  // if (!ok) return res.status(202).send({
-  //     message: "用户名中存在敏感词"
-  // });
-  db.query("SELECT uid FROM userInfo WHERE name=?", [name], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    if (data.length) return res.status(202).send({
-      message: "此用户名已被注册"
-    });
-    else {
-      const time = new Date();
-      const password = bcrypt.hashSync(pwd, 12);
-      db.query("INSERT INTO userInfo(name,pwd,reg_time,email) values (?,?,?,?)", [name, password, time, email], (err, data) => {
-        if (err) return res.status(202).send({
-          message: err
-        });
-        if (data.affectedRows > 0) {
-          req.session.verifyCode = null;
-          return res.status(200).send({
-            message: 'success'
-          });
-        } else {
-          return res.status(202).send({
-            message: "sql error"
-          });
-        }
-      });
-    }
-  })
-}
+const NAME_REGEX = /^[A-Za-z0-9]+$/;
+const EMAIL_REGEX = /^\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/;
 
-exports.login = async (req, res) => {
-  const name = req.body.name;
-  const pwd = req.body.pwd;
+const revokeAllSessions = async (uid, curToken) => {
+  const sessions = await db.query(
+    'SELECT token FROM userSession WHERE uid=? AND TIMESTAMPDIFF(SECOND,time,NOW()) < ?',
+    [uid, config.SESSION.expire / 1000]
+  );
+  const tokens = sessions.map((s) => s.token).filter((t) => t !== curToken);
+  if (!tokens.length) return;
+  await db.query('UPDATE sessions SET expires=? WHERE session_id in(?)', [0, tokens]);
+  await db.query('UPDATE userSession SET time=? WHERE token in(?)', [new Date(0), tokens]);
+};
 
-  if (!name || !pwd) {
-    return res.status(202).send({
-      message: "请确认信息完善"
-    });
+exports.reg = handler(async (req, res) => {
+  const { name, pwd, rePwd } = req.body;
+  const verified = req.session.verifiedEmail;
+  if (!verified || !verified.email) return fail(res, '请先验证邮箱');
+  if (Date.now() > verified.expire) return fail(res, '操作超时，请重新绑定邮箱');
+  if (!name || !pwd || !rePwd) return fail(res, '请确认信息完善');
+  if (name.length < 3 || name.length > 15) return fail(res, '用户名长度应在3~15之间');
+  if (!NAME_REGEX.test(name)) return fail(res, '用户名应只包含字母或数字');
+  if (pwd.length > 31 || pwd.length < 6) return fail(res, '密码长度应在6~31之间');
+  if (pwd !== rePwd) return fail(res, '两次输入的密码不一致');
+
+  const exist = await db.exists('SELECT uid FROM userInfo WHERE name=?', [name]);
+  if (exist) return fail(res, '此用户名已被注册');
+
+  const password = bcrypt.hashSync(pwd, 12);
+  const r = await db.query(
+    'INSERT INTO userInfo(name,pwd,reg_time,email) values (?,?,?,?)',
+    [name, password, new Date(), verified.email]
+  );
+  if (!r.affectedRows) return fail(res, 'sql error');
+
+  req.session.verifyCode = null;
+  return ok(res);
+});
+
+exports.login = handler(async (req, res) => {
+  const { name, pwd } = req.body;
+  if (!name || !pwd) return fail(res, '请确认信息完善');
+
+  const user = await db.one('SELECT * FROM userInfo WHERE name=?', [name]);
+  if (!user) return fail(res, '请先注册后再登录');
+  if (!user.inUse) {
+    recordEvent(req, 'user.loginFail.userBlocked', null, user.uid);
+    return fail(res, '你号没了');
   }
-  db.query("SELECT * FROM userInfo WHERE name=?", [name], (err, data) => {
-    if (!data.length) return res.status(202).send({
-      message: "请先注册后再登录"
-    });
-    if (err) return res.status(202).send({
-      message: err
-    });
-    const uid = data[0].uid, password = data[0].pwd, inUse = data[0].inUse;
-    if (!inUse) {
-      recordEvent(req, 'user.loginFail.userBlocked', null, uid);
-      return res.status(202).send({
-        message: '你号没了'
-      });
-    }
-    if (bcrypt.compareSync(pwd, password)) {
-      req.session.uid = uid;
-      req.session.name = data[0].name;
-      req.session.email = data[0].email;
-      req.session.gid = data[0].gid;
-      recordEvent(req, 'user.login');
-      db.query("UPDATE userInfo SET login_time=? WHERE uid=?", [new Date(), uid]);
-      db.query("INSERT INTO userSession(uid,token,browser,os,loginIp,loginLoc,time,lastact) values (?,?,?,?,?,?,?,?)",
-        [uid, req.sessionID, `${req.useragent.browser.name} ${req.useragent.browser.version}`, `${req.useragent.os.name} ${req.useragent.os.version}`, req.session.ip, ip2loc(req.session.ip), new Date(), new Date()]);
-      return res.status(200).send({ message: 'success' })
-    } else {
-      recordEvent(req, 'user.loginFail.wrongPassword', null, uid);
-      return res.status(202).send({ message: "密码错误" })
-    }
+  if (!bcrypt.compareSync(pwd, user.pwd)) {
+    recordEvent(req, 'user.loginFail.wrongPassword', null, user.uid);
+    return fail(res, '密码错误');
+  }
+
+  req.session.uid = user.uid;
+  req.session.name = user.name;
+  req.session.email = user.email;
+  req.session.gid = user.gid;
+  recordEvent(req, 'user.login');
+
+  const now = new Date();
+  await db.query('UPDATE userInfo SET login_time=? WHERE uid=?', [now, user.uid]);
+  await db.query(
+    'INSERT INTO userSession(uid,token,browser,os,loginIp,loginLoc,time,lastact) values (?,?,?,?,?,?,?,?)',
+    [
+      user.uid,
+      req.sessionID,
+      `${req.useragent.browser.name} ${req.useragent.browser.version}`,
+      `${req.useragent.os.name} ${req.useragent.os.version}`,
+      req.session.ip,
+      ip2loc(req.session.ip),
+      now,
+      now,
+    ]
+  );
+  return ok(res);
+});
+
+exports.getUserInfo = handler(async (req, res) => {
+  if (!req.session.uid) return fail(res, '请先登录');
+  const user = await db.one('SELECT * FROM userInfo WHERE uid=?', [req.session.uid]);
+  if (!user) return fail(res, '获取用户信息错误');
+  if (!user.inUse) {
+    req.session.destroy();
+    return fail(res, '请先登录');
+  }
+  req.session.name = user.name;
+  req.session.email = user.email;
+  req.session.gid = user.gid;
+  req.session.avatar = user.qq
+    ? `https://q1.qlogo.cn/g?b=qq&nk=${user.qq}&s=3`
+    : '/default-avatar.svg';
+  req.session.preferenceLang = user.preferenceLang;
+  return ok(res, {
+    uid: req.session.uid,
+    name: req.session.name,
+    email: req.session.email,
+    ip: req.session.ip,
+    gid: req.session.gid,
+    avatar: req.session.avatar,
+    preferenceLang: req.session.preferenceLang,
   });
-}
+});
 
-exports.getUserInfo = (req, res) => {
-  if (req.session.uid) {
-    db.query("SELECT * FROM userInfo WHERE uid=?", [req.session.uid], (err, data) => {
-      if (!data.length) return res.status(202).send({
-        message: "获取用户信息错误"
-      });
-      if (err) return res.status(202).send({
-        message: err
-      });
-      req.session.name = data[0].name;
-      req.session.email = data[0].email;
-      req.session.gid = data[0].gid;
-      if (!data[0].inUse) {
-        req.session.destroy();
-        return res.status(202).send({ message: "请先登录" });
-      }
-      if (data[0].qq)
-        req.session.avatar = `https://q1.qlogo.cn/g?b=qq&nk=${data[0].qq}&s=3`
-      else req.session.avatar = '/default-avatar.svg'
-      req.session.preferenceLang = data[0].preferenceLang;
-      return res.status(200).send({
-        uid: req.session.uid,
-        name: req.session.name,
-        email: req.session.email,
-        ip: req.session.ip,
-        gid: req.session.gid,
-        avatar: req.session.avatar,
-        preferenceLang: req.session.preferenceLang
-      });
-    });
-  }
-  else return res.status(202).send({ message: "请先登录" });
-}
-
-exports.logout = (req, res) => {
+exports.logout = handler(async (req, res) => {
   recordEvent(req, 'user.logout');
-  db.query("UPDATE userSession SET time=? WHERE token=?", [new Date(0), req.sessionID]);
+  await db.query('UPDATE userSession SET time=? WHERE token=?', [new Date(0), req.sessionID]);
   req.session.destroy();
-  return res.status(200).send({ message: "success" });
-}
+  return ok(res);
+});
 
 let lastSent = {};
 
-exports.sendEmailVerifyCode = async (req, res) => {
-  const email = req.body.email;
-  // const retoken = req.body.retoken;
-  // let recapt = await axios.get("https://www.recaptcha.net/recaptcha/api/siteverify", {
-  //   params: {
-  //     secret: "6LcEKJIkAAAAACAlGysXJJowd7Vrcbc08Ghtd58C",
-  //     response: retoken
-  //   }
-  // });
-  // if (!recapt.data.success) {
-  //   return res.status(202).send({
-  //     message: "请先进行人机验证"
-  //   })
-  // }
+exports.sendEmailVerifyCode = handler(async (req, res) => {
+  const { email } = req.body;
 
   if (lastSent[req.session.ip]) {
-    let rest = (new Date().getTime() - lastSent[req.session.ip] - 30 * 1000);
-    if (rest < 0) {
-      return res.status(202).send({
-        message: `请 ${Math.ceil(rest / -1000)} 秒后再试`
-      })
-    }
+    const rest = Date.now() - lastSent[req.session.ip] - 30 * 1000;
+    if (rest < 0) return fail(res, `请 ${Math.ceil(rest / -1000)} 秒后再试`);
   }
+  if (!EMAIL_REGEX.test(email)) return fail(res, '请检查邮箱是否合法');
 
-  const emailExp = /^\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/;
-  if (!emailExp.test(email)) {
-    return res.status(202).send({
-      message: "请检查邮箱是否合法"
-    })
-  }
-  let verifyCode = "";
-  const mp = 'abcdefghijklmnpqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ1234567890';
-  for (let i = 0; i < 6; i++) verifyCode += mp.charAt(Math.floor(Math.random() * 60));
+  const charset = 'abcdefghijklmnpqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ1234567890';
+  let verifyCode = '';
+  for (let i = 0; i < 6; i++) verifyCode += charset.charAt(Math.floor(Math.random() * 60));
 
-  const tim = new Date();
   req.session.verifyCode = {
     code: verifyCode,
-    expire: tim.getTime() + 3 * 60 * 1000,
-    email: email
-  }
+    expire: Date.now() + 3 * 60 * 1000,
+    email,
+  };
 
-  let transporter = mail.createTransport({
+  const transporter = mail.createTransport({
     host: 'smtp.163.com',
     port: 465,
     secureConnection: true,
-    auth: {
-      user: config.EMAIL.username,
-      pass: config.EMAIL.password
-    }
-  })
+    auth: { user: config.EMAIL.username, pass: config.EMAIL.password },
+  });
 
-  let mailOptions = {
+  const mailOptions = {
     from: 'nywojservice@163.com',
     to: email,
-    subject: 'nywOJ绑定邮箱验证码',
-    text: "你正在nywOJ进行绑定邮箱操作,验证码为 " + verifyCode + "\n该验证码3分钟内有效。"
-  }
+    subject: req.body.update ? 'nywOJ修改邮箱验证码' : 'nywOJ绑定邮箱验证码',
+    text: req.body.update
+      ? `你正在nywOJ进行修改邮箱操作(用户名: ${req.session.name}), 验证码为 ${verifyCode}\n该验证码3分钟内有效。`
+      : `你正在nywOJ进行绑定邮箱操作,验证码为 ${verifyCode}\n该验证码3分钟内有效。`,
+  };
 
-  if (req.body.update) {
-    mailOptions.subject = 'nywOJ修改邮箱验证码';
-    mailOptions.text = "你正在nywOJ进行修改邮箱操作(用户名: " + req.session.name + "), 验证码为 " + verifyCode + "\n该验证码3分钟内有效。"
-  }
   if (req.session.uid) {
-    recordEvent(req, 'auth.sendEmailVerifyCode', {
-      to: email
-    });
+    recordEvent(req, 'auth.sendEmailVerifyCode', { to: email });
   }
-  transporter.sendMail(mailOptions, (err) => {
-    if (!err) {
-      lastSent[req.session.ip] = new Date().getTime();
-      return res.status(200).send({ message: "success" });
-    } else {
-      return res.status(202).send({ message: err });
-    }
-  })
-}
 
-exports.setUserEmail = async (req, res) => {
+  await new Promise((resolve, reject) => {
+    transporter.sendMail(mailOptions, (err) => (err ? reject(err) : resolve()));
+  });
+  lastSent[req.session.ip] = Date.now();
+  return ok(res);
+});
+
+exports.setUserEmail = handler(async (req, res) => {
   const userCode = req.body.code;
-  if (!req.session.verifyCode || !userCode) {
-    return res.status(202).send({ message: "请确认信息完善且操作正确" });
-  }
-  const verifycode = req.session.verifyCode.code;
-  const expire = req.session.verifyCode.expire;
-  if (userCode !== verifycode) {
-    return res.status(202).send({ message: "验证码错误" });
-  }
-  const time = new Date().getTime();
-  if (time > expire) {
-    return res.status(202).send({ message: "验证码超时" });
-  }
-  db.query("SELECT email FROM userInfo WHERE email=?", [req.session.verifyCode.email], (err, data) => {
-    if (err) return res.status(202).send({
-      message: err
-    });
-    if (data.length) return res.status(202).send({
-      message: "此邮箱已绑定过其他账号"
-    });
-    else {
-      if (req.body.update) {
-        db.query("SELECT email FROM userInfo WHERE uid=?", [req.session.uid], (err2, data2) => {
-          if (err2) {
-            return res.status(202).send({ message: err2 });
-          }
-          const detail = {};
-          detail.email = {
-            'old': data2[0].email,
-            'new': req.session.verifyCode.email,
-          }
-          db.query("UPDATE userInfo SET email=? WHERE uid=?",
-            [req.session.verifyCode.email, req.session.uid], (err3, data3) => {
-              if (err3) return res.status(202).send({
-                message: err3
-              });
-              req.session.email = req.session.verifyCode.email;
-              revokeAllSessions(req.session.uid, req.sessionID);
-              recordEvent(req, 'auth.changeEmail', detail);
-              req.session.verifyCode = null;
-              return res.status(200).send({ message: "更新邮箱成功" });
-            });
-        })
-      }
-      else {
-        req.session.verifiedEmail = {
-          email: req.session.verifyCode.email,
-          expire: new Date().getTime() + 10 * 60 * 1000,
-        }
-        req.session.verifyCode = null;
-        return res.status(200).send({ message: "验证成功,请在10分钟内完成注册操作" });
-      }
-    }
-  })
-}
+  if (!req.session.verifyCode || !userCode) return fail(res, '请确认信息完善且操作正确');
+  if (userCode !== req.session.verifyCode.code) return fail(res, '验证码错误');
+  if (Date.now() > req.session.verifyCode.expire) return fail(res, '验证码超时');
 
-exports.getUserPublicInfo = (req, res) => {
-  const uid = req.body.uid;
-  db.query("SELECT uid,name,email,reg_time,login_time,clickCnt,inUse,gid,motto,qq,preferenceLang FROM userInfo WHERE uid=?", [uid], (err, data) => {
-    if (err) {
-      return res.status(202).send({ message: err });
-    }
-    if (!data.length) {
-      return res.status(202).send({ message: '无此用户' });
-    }
-    if (data[0].reg_time)
-      data[0].reg_time = briefFormat(data[0].reg_time);
-    if (data[0].login_time)
-      data[0].login_time = briefFormat(data[0].login_time);
-    if (req.session.gid !== 3 && req.session.uid !== data[0].uid) {
-      delete data[0].login_time;
-      delete data[0].email;
-    }
-    return res.status(200).send({ info: data[0] });
-  });
-}
+  const newEmail = req.session.verifyCode.email;
+  const taken = await db.exists('SELECT email FROM userInfo WHERE email=?', [newEmail]);
+  if (taken) return fail(res, '此邮箱已绑定过其他账号');
 
-exports.setUserMotto = async (req, res) => {
+  if (!req.body.update) {
+    req.session.verifiedEmail = {
+      email: newEmail,
+      expire: Date.now() + 10 * 60 * 1000,
+    };
+    req.session.verifyCode = null;
+    return ok(res, { message: '验证成功,请在10分钟内完成注册操作' });
+  }
+
+  const cur = await db.one('SELECT email FROM userInfo WHERE uid=?', [req.session.uid]);
+  await db.query('UPDATE userInfo SET email=? WHERE uid=?', [newEmail, req.session.uid]);
+  req.session.email = newEmail;
+  await revokeAllSessions(req.session.uid, req.sessionID);
+  recordEvent(req, 'auth.changeEmail', { email: { old: cur ? cur.email : null, new: newEmail } });
+  req.session.verifyCode = null;
+  return ok(res, { message: '更新邮箱成功' });
+});
+
+exports.getUserPublicInfo = handler(async (req, res) => {
+  const { uid } = req.body;
+  const info = await db.one(
+    'SELECT uid,name,email,reg_time,login_time,clickCnt,inUse,gid,motto,qq,preferenceLang FROM userInfo WHERE uid=?',
+    [uid]
+  );
+  if (!info) return fail(res, '无此用户');
+  if (info.reg_time) info.reg_time = briefFormat(info.reg_time);
+  if (info.login_time) info.login_time = briefFormat(info.login_time);
+  if (req.session.gid !== 3 && req.session.uid !== info.uid) {
+    delete info.login_time;
+    delete info.email;
+  }
+  return ok(res, { info });
+});
+
+exports.setUserMotto = handler(async (req, res) => {
   const motto = req.body.data;
-  if (motto.length > 1000) {
-    return res.status(202).send({ message: "个人主页长度应在1000以内" });
+  if (motto.length > 1000) return fail(res, '个人主页长度应在1000以内');
+  await db.query('UPDATE userInfo SET motto=? WHERE uid=?', [motto, req.session.uid]);
+  return ok(res);
+});
+
+exports.listSessions = handler(async (req, res) => {
+  const list = await db.query(
+    'SELECT * FROM userSession WHERE uid=? AND TIMESTAMPDIFF(SECOND,lastact,NOW()) < ? AND time != ? ORDER BY lastact DESC',
+    [req.session.uid, config.SESSION.expire / 1000, new Date(0)]
+  );
+  const now = Date.now();
+  for (const s of list) {
+    delete s.id;
+    s.lastact = s.token === req.sessionID ? '当前会话' : msFormat(now - new Date(s.lastact).getTime());
+    s.time = Format(s.time);
   }
-  db.query("UPDATE userInfo SET motto=? WHERE uid=?", [motto, req.session.uid], (err, data) => {
-    if (err) {
-      return res.status(202).send({ message: err });
-    }
-    return res.status(200).send({ message: 'success' });
-  });
-}
+  return ok(res, { data: list });
+});
 
-exports.listSessions = (req, res) => {
-  db.query("SELECT * FROM userSession WHERE uid=? AND TIMESTAMPDIFF(SECOND,lastact,NOW()) < ? AND time != ? ORDER BY lastact DESC", [req.session.uid, config.SESSION.expire / 1000, new Date(0)], (err, data) => {
-    if (err) {
-      return res.status(202).send({ message: err });
-    }
-    const now = new Date().getTime();
-    for (let i = 0; i < data.length; i++) {
-      delete data[i].id;
-      if (data[i].token === req.sessionID)
-        data[i].lastact = '当前会话';
-      else data[i].lastact = msFormat(now - new Date(data[i].lastact).getTime());
-      data[i].time = Format(data[i].time);
-    }
-    return res.status(200).send({ data: data });
-  })
-}
-
-exports.revokeSession = (req, res) => {
+exports.revokeSession = handler(async (req, res) => {
   if (req.body.revokeAll) {
-    revokeAllSessions(req.session.uid, req.sessionID);
+    await revokeAllSessions(req.session.uid, req.sessionID);
     recordEvent(req, 'auth.revokeAllSessions');
-    return res.status(200).send({ message: "ok" });
+    return ok(res, { message: 'ok' });
   }
-  const token = req.body.token;
-  db.query("SELECT * FROM userSession WHERE uid=? AND token=?", [req.session.uid, token], (err, data) => {
-    if (err) {
-      return res.status(202).send({ message: err });
-    }
-    if (!data.length) {
-      return res.status(202).send({ message: '无效token' });
-    }
-    recordEvent(req, 'auth.revokeSession');
-    db.query("UPDATE sessions SET expires=? WHERE session_id=?", [0, token]);
-    db.query("UPDATE userSession SET time=? WHERE uid=? AND token=?", [new Date(0), req.session.uid, token]);
-    return res.status(200).send({ message: "ok" });
-  })
-}
+  const { token } = req.body;
+  const exists = await db.exists('SELECT id FROM userSession WHERE uid=? AND token=?', [req.session.uid, token]);
+  if (!exists) return fail(res, '无效token');
 
-const revokeAllSessions = async (uid, curToken) => {
-  db.query("SELECT * FROM userSession WHERE uid=? AND TIMESTAMPDIFF(SECOND,time,NOW()) < ?", [uid, config.SESSION.expire / 1000], (err, data) => {
-    if (err) {
-      console.log(err);
-      return;
-    }
-    let sessionList = [];
-    for (i in data) {
-      if (data[i].token !== curToken)
-        sessionList.push(data[i].token);
-    }
-    if (!sessionList.length)
-      return;
-    db.query("UPDATE sessions SET expires=? WHERE session_id in(?)", [0, sessionList], (err, data) => {
-      if (err)
-        console.log(err);
-    });
-    db.query("UPDATE userSession SET time=? WHERE token in(?)", [new Date(0), sessionList], (err, data) => {
-      if (err)
-        console.log(err);
-    });
-  })
-  return;
-}
+  recordEvent(req, 'auth.revokeSession');
+  await db.query('UPDATE sessions SET expires=? WHERE session_id=?', [0, token]);
+  await db.query('UPDATE userSession SET time=? WHERE uid=? AND token=?', [new Date(0), req.session.uid, token]);
+  return ok(res, { message: 'ok' });
+});
 
-exports.updateUserPublicInfo = (req, res) => {
-  const info = req.body.userInfo;
-  db.query("SELECT * FROM userInfo WHERE uid=?", [req.session.uid], (err, data) => {
-    if (err) {
-      return res.status(202).send({ message: err });
-    }
-    db.query("UPDATE userInfo SET qq=?,motto=?,preferenceLang=? WHERE uid=?", [info.qq, info.motto, info.preferenceLang, req.session.uid], (err2, data2) => {
-      if (err2) {
-        return res.status(202).send({ message: err2 });
-      }
-      const detail = {};
-      if (data[0].qq !== info.qq)
-        detail.qq = {
-          'old': data[0].qq,
-          'new': info.qq,
-        }
-      if (data[0].motto !== info.motto)
-        detail.motto = {
-          'old': data[0].motto,
-          'new': info.motto,
-        }
-      if (data[0].preferenceLang !== info.preferenceLang)
-        detail.preferenceLang = {
-          'old': data[0].preferenceLang,
-          'new': info.preferenceLang,
-        }
-      recordEvent(req, 'user.updateProfile', detail)
-      return res.status(200).send({ message: "ok" });
-    });
-  })
-}
-
-exports.listAudits = (req, res) => {
-  const pageId = req.body.pageId, pageSize = 10;
-  db.query("SELECT * FROM userAudit WHERE uid=? ORDER BY id DESC LIMIT ?,?",
-    [req.session.uid, (pageId - 1) * pageSize, pageSize], (err, data) => {
-      if (err) {
-        return res.status(202).send({ message: err });
-      }
-      for (let i = 0; i < data.length; i++) {
-        delete data[i].id;
-        data[i].eventExp = eventExp[data[i].event];
-        data[i].event = eventList[data[i].event];
-        data[i].time = Format(data[i].time);
-      }
-      db.query("SELECT COUNT(*) as cnt FROM userAudit WHERE uid=?", [req.session.uid], (err2, data2) => {
-        if (err2) {
-          return res.status(202).send({ message: err2 });
-        }
-        return res.status(200).send({ data: data, total: data2[0].cnt });
-      })
-    })
-}
-
-exports.modifyPassword = (req, res) => {
-  const newPwd = req.body.newPwd;
-  if (newPwd.new !== newPwd.rep) {
-    return res.status(202).send({ message: "两次密码不一致" });
+exports.updateUserPublicInfo = handler(async (req, res) => {
+  const info = req.body.userInfo || {};
+  const before = await db.one('SELECT qq,motto,preferenceLang FROM userInfo WHERE uid=?', [req.session.uid]);
+  await db.query(
+    'UPDATE userInfo SET qq=?,motto=?,preferenceLang=? WHERE uid=?',
+    [info.qq, info.motto, info.preferenceLang, req.session.uid]
+  );
+  const detail = {};
+  for (const key of ['qq', 'motto', 'preferenceLang']) {
+    if (before && before[key] !== info[key]) detail[key] = { old: before[key], new: info[key] };
   }
-  if (newPwd.new.length > 31 || newPwd.new.length < 6) {
-    return res.status(202).send({
-      message: "密码长度应在6~31之间"
-    })
+  recordEvent(req, 'user.updateProfile', detail);
+  return ok(res, { message: 'ok' });
+});
+
+exports.listAudits = handler(async (req, res) => {
+  const { offset, limit } = paginate(req, 10);
+  const list = await db.query(
+    'SELECT * FROM userAudit WHERE uid=? ORDER BY id DESC LIMIT ?,?',
+    [req.session.uid, offset, limit]
+  );
+  for (const r of list) {
+    delete r.id;
+    r.eventExp = eventExp[r.event];
+    r.event = eventList[r.event];
+    r.time = Format(r.time);
   }
-  db.query("SELECT pwd FROM userInfo WHERE uid=?", [req.session.uid], (err, data) => {
-    if (err) {
-      return res.status(202).send({ message: err });
-    }
-    if (bcrypt.compareSync(newPwd.old, data[0].pwd)) {
-      const updPwd = bcrypt.hashSync(newPwd.new, 12);
-      db.query('UPDATE userInfo SET pwd=? WHERE uid=?', [updPwd, req.session.uid], (err2, data2) => {
-        if (err2) {
-          return res.status(202).send({ message: err2 });
-        }
-        recordEvent(req, 'auth.changePassword');
-        revokeAllSessions(req.session.uid, req.sessionID);
-        return res.status(200).send({ message: "ok" });
-      })
-    } else {
-      return res.status(202).send({ message: "旧密码错误" });
-    }
-  });
-}
+  const cnt = await db.one('SELECT COUNT(*) as cnt FROM userAudit WHERE uid=?', [req.session.uid]);
+  return ok(res, { data: list, total: cnt.cnt });
+});
+
+exports.modifyPassword = handler(async (req, res) => {
+  const { newPwd } = req.body;
+  if (newPwd.new !== newPwd.rep) return fail(res, '两次密码不一致');
+  if (newPwd.new.length > 31 || newPwd.new.length < 6) return fail(res, '密码长度应在6~31之间');
+
+  const user = await db.one('SELECT pwd FROM userInfo WHERE uid=?', [req.session.uid]);
+  if (!user || !bcrypt.compareSync(newPwd.old, user.pwd)) return fail(res, '旧密码错误');
+
+  const updPwd = bcrypt.hashSync(newPwd.new, 12);
+  await db.query('UPDATE userInfo SET pwd=? WHERE uid=?', [updPwd, req.session.uid]);
+  recordEvent(req, 'auth.changePassword');
+  await revokeAllSessions(req.session.uid, req.sessionID);
+  return ok(res, { message: 'ok' });
+});

--- a/server/app.js
+++ b/server/app.js
@@ -46,7 +46,7 @@ app.use((req, res, next) => {
 app.use((req, res, next) => {
   req.useragent = parser(req.headers['user-agent']);
   if (req.session.uid) {
-    db.query('UPDATE userSession SET lastact=? WHERE token=? AND uid=?', [new Date(), req.sessionID, req.session.uid]);
+    db.query('UPDATE userSession SET lastact=? WHERE token=? AND uid=?', [new Date(), req.sessionID, req.session.uid]).catch((err) => console.log(err));
     if (req.url.match('^\/api\/admin') && req.session.gid !== 3)
       return res.status(403).end('403 Forbidden');
     next();

--- a/server/db/format.js
+++ b/server/db/format.js
@@ -1,0 +1,50 @@
+const { Format, briefFormat, kbFormat } = require('../static');
+
+const judgeRes = [
+  'Waiting',
+  'Pending',
+  'Rejudging',
+  'Compilation Error',
+  'Accepted',
+  'Wrong Answer',
+  'Time Limit Exceeded',
+  'Memory Limit Exceeded',
+  'Runtime Error',
+  'Segmentation Fault',
+  'Output Limit Exceeded',
+  'Dangerous System Call',
+  'System Error',
+  'Canceled',
+  'Skipped',
+];
+
+const ptype = ['传统文本比较', 'Special Judge'];
+const ctype = ['OI', 'IOI'];
+const cstatus = ['未开始', '正在进行', '等待测评', '已结束'];
+
+const formatSubmissionRow = (row) => {
+  if (!row) return row;
+  if (row.submitTime) row.submitTime = Format(row.submitTime);
+  if (typeof row.judgeResult === 'number') row.judgeResult = judgeRes[row.judgeResult];
+  if (typeof row.memory === 'number') row.memory = kbFormat(row.memory);
+  return row;
+};
+
+const formatCaseRow = (row) => {
+  if (!row) return row;
+  if (typeof row.result === 'number') row.result = judgeRes[row.result];
+  if (typeof row.memory === 'number') row.memory = kbFormat(row.memory);
+  return row;
+};
+
+module.exports = {
+  judgeRes,
+  ptype,
+  ctype,
+  cstatus,
+  formatSubmissionRow,
+  formatCaseRow,
+  Format,
+  briefFormat,
+  kbFormat,
+};

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -1,13 +1,72 @@
 const mysql = require('mysql');
 const config = require('../config.json');
-const db = mysql.createPool({
+
+const pool = mysql.createPool({
   host: config.DB.host,
   port: config.DB.port,
   user: config.DB.username,
   password: config.DB.password,
   database: config.DB.databasename,
   charset: 'utf8mb4',
-  collation: 'utf8mb4_unicode_ci'
+  collation: 'utf8mb4_unicode_ci',
 });
 
-module.exports = db;
+const wrap = (runner) => {
+  const query = (sql, params) =>
+    new Promise((resolve, reject) => {
+      runner.query(sql, params, (err, rows) => {
+        if (err) reject(err);
+        else resolve(rows);
+      });
+    });
+  const one = async (sql, params) => {
+    const rows = await query(sql, params);
+    return rows && rows.length ? rows[0] : null;
+  };
+  const exists = async (sql, params) => {
+    const rows = await query(sql, params);
+    return !!(rows && rows.length);
+  };
+  const column = async (sql, params, key) => {
+    const rows = await query(sql, params);
+    return rows.map((r) => (key ? r[key] : Object.values(r)[0]));
+  };
+  return { query, one, exists, column };
+};
+
+const base = wrap(pool);
+
+const tx = (work) =>
+  new Promise((resolve, reject) => {
+    pool.getConnection((err, conn) => {
+      if (err) return reject(err);
+      conn.beginTransaction(async (beginErr) => {
+        if (beginErr) {
+          conn.release();
+          return reject(beginErr);
+        }
+        try {
+          const result = await work(wrap(conn));
+          conn.commit((commitErr) => {
+            conn.release();
+            if (commitErr) reject(commitErr);
+            else resolve(result);
+          });
+        } catch (workErr) {
+          conn.rollback(() => {
+            conn.release();
+            reject(workErr);
+          });
+        }
+      });
+    });
+  });
+
+module.exports = {
+  pool,
+  query: base.query,
+  one: base.one,
+  exists: base.exists,
+  column: base.column,
+  tx,
+};

--- a/server/db/util.js
+++ b/server/db/util.js
@@ -1,0 +1,46 @@
+const handler = (fn) => async (req, res, next) => {
+  try {
+    await fn(req, res, next);
+  } catch (err) {
+    if (res.headersSent) return;
+    const message = err && err.sqlMessage ? err.sqlMessage : err && err.message ? err.message : String(err);
+    console.error('handler error:', err && err.stack ? err.stack : err);
+    res.status(202).send({ message });
+  }
+};
+
+const fail = (res, message, status = 202) => res.status(status).send({ message });
+const ok = (res, payload = { message: 'success' }) => res.status(200).send(payload);
+
+const requireRole = (minGid) => (req, res, next) => {
+  if ((req.session.gid || 1) < minGid) {
+    return res.status(403).end('403 Forbidden');
+  }
+  return next();
+};
+
+const paginate = (req, defaultSize = 20) => {
+  let pageId = parseInt(req.body.pageId, 10);
+  if (!pageId || pageId < 1) pageId = 1;
+  const pageSize = parseInt(req.body.pageSize, 10) || defaultSize;
+  return { pageId, pageSize, offset: (pageId - 1) * pageSize, limit: pageSize };
+};
+
+// conditions: array of [clause, ...values] — entries with empty/null/undefined values are skipped.
+// Use the form ['col=?', value]; pass null/undefined/'' to omit the clause entirely.
+const buildWhere = (conditions, prefix = '') => {
+  const parts = [];
+  const params = [];
+  for (const cond of conditions) {
+    if (!cond) continue;
+    const [clause, ...vals] = cond;
+    if (vals.length && vals.some((v) => v === undefined || v === null || v === '')) continue;
+    parts.push(clause);
+    params.push(...vals);
+  }
+  if (!parts.length) return { where: prefix ? ` WHERE ${prefix}` : '', params: [] };
+  const head = prefix ? ` WHERE ${prefix} AND ` : ' WHERE ';
+  return { where: head + parts.join(' AND '), params };
+};
+
+module.exports = { handler, fail, ok, requireRole, paginate, buildWhere };

--- a/server/static.js
+++ b/server/static.js
@@ -101,17 +101,7 @@ exports.recordEvent = (req, reason, detail, uid) => {
   db.query('INSERT INTO userAudit(uid,event,ip,iploc,time,browser,os,detail) values(?,?,?,?,?,?,?,?)', [
     req.session.uid || uid, eventId, req.session.ip, this.ip2loc(req.session.ip), new Date(),
     `${req.useragent.browser.name} ${req.useragent.browser.version}`, `${req.useragent.os.name} ${req.useragent.os.version}`, detail ? JSON.stringify(detail, null, 2) : null
-  ], (err, data) => {
-    if (err)
-      console.log(err);
-  });
+  ]).catch((err) => console.log(err));
 }
 
-exports.queryPromise = (sql, values) => {
-  return new Promise((resolve, reject) => {
-    db.query(sql, values, (error, results) => {
-      if (error) reject(error);
-      else resolve(results);
-    });
-  });
-}
+exports.queryPromise = (sql, values) => db.query(sql, values);


### PR DESCRIPTION
## Summary

- Replaced raw `mysql` pool callbacks with a Promise-first `db` wrapper (`query`, `one`, `exists`, `column`, `tx`) in `server/db/index.js`
- Introduced `server/db/util.js` with shared route helpers: `handler` (catch wrapper), `fail`, `ok`, `requireRole`, `paginate`, `buildWhere`
- Introduced `server/db/format.js` centralizing constants previously duplicated across 5+ files (`judgeRes`, `ptype`, `ctype`, `cstatus`) and shared row formatters (`formatSubmissionRow`, `formatCaseRow`)
- Rewrote all 10 API modules to `async/await`, eliminating ~15 inline `new Promise` wrappers, nested callbacks, and per-handler `if (err) return res.status(202)...` boilerplate
- Added `db.tx()` transaction support; used in `contest.submit` to atomically insert submission + update stats + manage registration
- Fixed pre-existing bug in `problem.getProblemList` where list query filtered on both `title` and `description` but count query only filtered on `title`

## What changed and why

The backend DB access was inconsistent — some code used raw `pool.query` with callbacks, some wrapped in `new Promise` inline, some used promise chains, and nearly every handler had copy-pasted error boilerplate. This refactor unifies all DB access behind a small promise-first wrapper, eliminates the boilerplate via shared helpers, and centralises duplicated constants.

Net result: **15 files changed, −910 lines** (1803 insertions, 2713 deletions).

## Reviewer notes

- `server/db/index.js`, `server/db/util.js`, `server/db/format.js` are the new foundation — review those first
- All files pass `node --check` syntax verification
- Server boots and loads `router.js` cleanly
- The judgeWorker files (`judgeWorker(C++).js`, `judgeWorker(Python3).js`, `judgeWorker(Baltamatica).js`) only had their inline DB promise wrappers replaced; judging logic is unchanged

## Test plan

- [ ] Boot server with `node app.js` — starts without error
- [ ] Submit a solution and verify judging completes (C++, Python3, Baltamatica workers)
- [ ] Check contest submission, scoreboard, and rejudge flows
- [ ] Verify admin panel user/problem management still works
- [ ] Test problem list search filtering (bug fix: count query now uses same filters as list query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)