### PR TITLE
feat(server): RBAC permission layer (PR 1/3)

### DIFF
--- a/server/api/user.js
+++ b/server/api/user.js
@@ -4,6 +4,7 @@ const db = require('../db');
 const { handler, fail, ok, paginate } = require('../db/util');
 const { Format, ip2loc, msFormat, recordEvent, eventList, eventExp, briefFormat } = require('../static');
 const config = require('../config.json');
+const { listGlobalKeys } = require('../auth/policy');
 
 const NAME_REGEX = /^[A-Za-z0-9]+$/;
 const EMAIL_REGEX = /^\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/;
@@ -98,6 +99,7 @@ exports.getUserInfo = handler(async (req, res) => {
     ? `https://q1.qlogo.cn/g?b=qq&nk=${user.qq}&s=3`
     : '/default-avatar.svg';
   req.session.preferenceLang = user.preferenceLang;
+  const permissions = req.perms ? listGlobalKeys(req.perms) : [];
   return ok(res, {
     uid: req.session.uid,
     name: req.session.name,
@@ -106,6 +108,7 @@ exports.getUserInfo = handler(async (req, res) => {
     gid: req.session.gid,
     avatar: req.session.avatar,
     preferenceLang: req.session.preferenceLang,
+    permissions,
   });
 });
 

--- a/server/app.js
+++ b/server/app.js
@@ -29,6 +29,8 @@ app.use(session({
 }));
 const parser = require('ua-parser-js');
 const db = require('./db/index');
+const { syncPermissionCatalog } = require('./auth/sync');
+const { attachPermissions } = require('./auth/middleware');
 
 app.use((req, res, next) => {
   const ip = req.headers['x-forwarded-for']?.split(',')[0] ||
@@ -43,11 +45,13 @@ app.use((req, res, next) => {
   }
 });
 
+app.use(attachPermissions);
+
 app.use((req, res, next) => {
   req.useragent = parser(req.headers['user-agent']);
   if (req.session.uid) {
     db.query('UPDATE userSession SET lastact=? WHERE token=? AND uid=?', [new Date(), req.sessionID, req.session.uid]).catch((err) => console.log(err));
-    if (req.url.match('^\/api\/admin') && req.session.gid !== 3)
+    if (req.url.match('^\/api\/admin') && !req.can('user.list'))
       return res.status(403).end('403 Forbidden');
     next();
   } else {
@@ -107,7 +111,14 @@ process.on('uncaughtException', (err) => {
   console.error('Uncaught Exception:', `Error: ${err.message}\nStack: ${err.stack}`);
 });
 
-app.listen(1234, () => {
-  console.log('success!!!');
-});
+syncPermissionCatalog()
+  .then(() => {
+    app.listen(1234, () => {
+      console.log('success!!!');
+    });
+  })
+  .catch((err) => {
+    console.error('permission catalog sync failed:', err && err.stack ? err.stack : err);
+    process.exit(1);
+  });
 

--- a/server/auth/middleware.js
+++ b/server/auth/middleware.js
@@ -1,0 +1,26 @@
+const { loadEffectivePermissions, can } = require('./policy');
+
+// Attaches req.perms and req.can(key, scope?). Always runs after session middleware.
+const attachPermissions = async (req, res, next) => {
+  try {
+    req.perms = await loadEffectivePermissions(req.session && req.session.uid);
+    req.can = (key, scope) => can(req.perms, key, scope);
+    return next();
+  } catch (err) {
+    return next(err);
+  }
+};
+
+// Express middleware factory. `opts.scopeFrom(req)` -> { type, id } | undefined.
+const requirePermission = (key, opts = {}) => async (req, res, next) => {
+  try {
+    if (!req.perms) req.perms = await loadEffectivePermissions(req.session && req.session.uid);
+    const scope = typeof opts.scopeFrom === 'function' ? opts.scopeFrom(req) : undefined;
+    if (!can(req.perms, key, scope)) return res.status(403).end('403 Forbidden');
+    return next();
+  } catch (err) {
+    return next(err);
+  }
+};
+
+module.exports = { attachPermissions, requirePermission };

--- a/server/auth/permissions.js
+++ b/server/auth/permissions.js
@@ -1,0 +1,82 @@
+// Permission catalog & builtin roles.
+// Edit here, restart server, and `syncPermissionCatalog()` will reconcile the DB.
+// `scopable: true` means a permission can be granted with a (resource_type, resource_id) scope.
+
+const PERMISSIONS = {
+  'problem.create':       { group: 'problem', name: '创建题目', description: '创建新题目' },
+  'problem.edit.any':     { group: 'problem', name: '编辑任意题目', description: '编辑非自己创建的题目', scopable: true },
+  'problem.delete.any':   { group: 'problem', name: '删除任意题目', description: '删除非自己创建的题目', scopable: true },
+  'problem.case.manage':  { group: 'problem', name: '管理题目数据', description: '上传/修改/下载测试数据', scopable: true },
+  'problem.view.private': { group: 'problem', name: '查看非公开题目', description: '查看 isPublic=0 的题目' },
+
+  'contest.create':                { group: 'contest', name: '创建比赛' },
+  'contest.edit.any':              { group: 'contest', name: '编辑任意比赛', scopable: true },
+  'contest.player.manage':         { group: 'contest', name: '管理比赛选手', scopable: true },
+  'contest.submission.view.cross': { group: 'contest', name: '跨比赛查看提交' },
+
+  'submission.view.any': { group: 'judge', name: '查看任意提交', description: '查看所有提交详情/代码' },
+  'submission.rejudge':  { group: 'judge', name: '重测提交', scopable: true },
+
+  'user.list':             { group: 'user', name: '查看用户列表' },
+  'user.edit':             { group: 'user', name: '编辑用户资料' },
+  'user.ban':              { group: 'user', name: '封禁/解封用户' },
+  'user.role.assign':      { group: 'user', name: '分配角色' },
+  'user.permission.grant': { group: 'user', name: '单点授权' },
+
+  'announcement.manage': { group: 'system', name: '管理公告' },
+  'paste.edit.any':      { group: 'system', name: '编辑他人 paste' },
+  'audit.view':          { group: 'system', name: '查看审计日志' },
+};
+
+const PROBLEM_SETTER_PERMS = [
+  'problem.create',
+  'problem.edit.any',
+  'problem.case.manage',
+  'problem.view.private',
+  'submission.view.any',
+];
+
+const CONTEST_MANAGER_PERMS = [
+  'contest.create',
+  'contest.edit.any',
+  'contest.player.manage',
+  'contest.submission.view.cross',
+];
+
+const JUDGE_ADMIN_PERMS = [
+  'submission.view.any',
+  'submission.rejudge',
+];
+
+const MODERATOR_PERMS = Array.from(new Set([
+  ...PROBLEM_SETTER_PERMS,
+  ...CONTEST_MANAGER_PERMS,
+  ...JUDGE_ADMIN_PERMS,
+]));
+
+const SUPER_ADMIN_PERMS = Object.keys(PERMISSIONS);
+
+const BUILTIN_ROLES = {
+  user:            { name: '普通用户',     legacy_gid: 1, description: '默认角色，无额外权限', permissions: [] },
+  problem_setter:  { name: '出题人',       legacy_gid: null, description: '可创建/编辑题目并管理数据', permissions: PROBLEM_SETTER_PERMS },
+  contest_manager: { name: '比赛管理员',   legacy_gid: null, description: '可创建并管理比赛', permissions: CONTEST_MANAGER_PERMS },
+  judge_admin:     { name: '判题管理员',   legacy_gid: null, description: '可重测并查看所有提交', permissions: JUDGE_ADMIN_PERMS },
+  moderator:       { name: '管理员',       legacy_gid: 2, description: '出题/办赛/判题三合一（兼容 gid=2）', permissions: MODERATOR_PERMS },
+  super_admin:     { name: '超级管理员',   legacy_gid: 3, description: '拥有全部权限（兼容 gid=3）', permissions: SUPER_ADMIN_PERMS },
+};
+
+const RESOURCE_TYPES = ['problem', 'contest'];
+
+// Permissions that can be granted by a resource owner (via the resource collaborator UI),
+// without needing the global `user.permission.grant` permission.
+const RESOURCE_GRANTABLE = {
+  problem: ['problem.edit.any', 'problem.case.manage', 'problem.delete.any'],
+  contest: ['contest.edit.any', 'contest.player.manage', 'submission.rejudge'],
+};
+
+module.exports = {
+  PERMISSIONS,
+  BUILTIN_ROLES,
+  RESOURCE_TYPES,
+  RESOURCE_GRANTABLE,
+};

--- a/server/auth/policy.js
+++ b/server/auth/policy.js
@@ -1,0 +1,91 @@
+const db = require('../db');
+
+// Process-wide cache: uid -> { perms, expiresAt }.
+// Invalidated explicitly by setUserRoles / grantUserPermission etc.
+const CACHE_TTL_MS = 60 * 1000;
+const cache = new Map();
+
+const buildEmpty = () => ({
+  global: new Set(),
+  denies: new Set(),
+  scoped: new Map(), // permKey -> Set<"type:id">
+});
+
+const loadEffectivePermissions = async (uid) => {
+  if (!uid) return buildEmpty();
+
+  const cached = cache.get(uid);
+  if (cached && cached.expiresAt > Date.now()) return cached.perms;
+
+  const perms = buildEmpty();
+
+  // Permissions inherited from roles (always allow; deny is only expressible at user level).
+  const rolePerms = await db.query(
+    `SELECT DISTINCT p.\`key\`
+     FROM user_roles ur
+     JOIN role_permissions rp ON rp.role_id = ur.role_id
+     JOIN permissions p ON p.id = rp.permission_id
+     WHERE ur.uid = ?`,
+    [uid]
+  );
+  for (const r of rolePerms) perms.global.add(r.key);
+
+  // Direct user grants and denies; honor expires_at.
+  const direct = await db.query(
+    `SELECT p.\`key\` AS \`key\`, up.effect, up.resource_type, up.resource_id, up.expires_at
+     FROM user_permissions up
+     JOIN permissions p ON p.id = up.permission_id
+     WHERE up.uid = ?`,
+    [uid]
+  );
+  const now = Date.now();
+  for (const row of direct) {
+    if (row.expires_at && new Date(row.expires_at).getTime() < now) continue;
+    if (row.effect === 'deny') {
+      // Denies are global by design (resource-scoped denies add complexity we don't need yet).
+      perms.denies.add(row.key);
+      continue;
+    }
+    if (row.resource_type && row.resource_id != null) {
+      let bucket = perms.scoped.get(row.key);
+      if (!bucket) {
+        bucket = new Set();
+        perms.scoped.set(row.key, bucket);
+      }
+      bucket.add(`${row.resource_type}:${row.resource_id}`);
+    } else {
+      perms.global.add(row.key);
+    }
+  }
+
+  cache.set(uid, { perms, expiresAt: Date.now() + CACHE_TTL_MS });
+  return perms;
+};
+
+const invalidate = (uid) => {
+  if (uid == null) cache.clear();
+  else cache.delete(uid);
+};
+
+// scope: { type, id } | undefined
+const can = (perms, key, scope) => {
+  if (!perms) return false;
+  if (perms.denies.has(key)) return false;
+  if (perms.global.has(key)) return true;
+  if (scope && scope.type && scope.id != null) {
+    const bucket = perms.scoped.get(key);
+    if (bucket && bucket.has(`${scope.type}:${scope.id}`)) return true;
+  }
+  return false;
+};
+
+// Convenience: flatten effective permission keys into an array (global only).
+// Used by getUserInfo to feed the frontend `$can` helper.
+const listGlobalKeys = (perms) => Array.from(perms.global).filter((k) => !perms.denies.has(k));
+
+module.exports = {
+  loadEffectivePermissions,
+  invalidate,
+  can,
+  listGlobalKeys,
+};

--- a/server/auth/sync.js
+++ b/server/auth/sync.js
@@ -1,0 +1,124 @@
+const db = require('../db');
+const { PERMISSIONS, BUILTIN_ROLES } = require('./permissions');
+
+const ensureSchema = async () => {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS permissions (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      \`key\`        VARCHAR(64)  NOT NULL UNIQUE,
+      \`group\`      VARCHAR(32)  NOT NULL,
+      name         VARCHAR(64)  NOT NULL,
+      description  VARCHAR(255) NULL,
+      scopable     TINYINT      NOT NULL DEFAULT 0
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS roles (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      \`key\`        VARCHAR(64)  NOT NULL UNIQUE,
+      name         VARCHAR(64)  NOT NULL,
+      description  VARCHAR(255) NULL,
+      builtin      TINYINT      NOT NULL DEFAULT 0,
+      legacy_gid   TINYINT      NULL UNIQUE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS role_permissions (
+      role_id        INT NOT NULL,
+      permission_id  INT NOT NULL,
+      PRIMARY KEY (role_id, permission_id),
+      CONSTRAINT fk_rp_role FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
+      CONSTRAINT fk_rp_perm FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS user_roles (
+      uid         INT NOT NULL,
+      role_id     INT NOT NULL,
+      granted_by  INT NULL,
+      granted_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (uid, role_id),
+      INDEX idx_role (role_id),
+      CONSTRAINT fk_ur_role FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS user_permissions (
+      id            INT AUTO_INCREMENT PRIMARY KEY,
+      uid           INT NOT NULL,
+      permission_id INT NOT NULL,
+      effect        ENUM('allow','deny') NOT NULL DEFAULT 'allow',
+      resource_type VARCHAR(32) NULL,
+      resource_id   INT         NULL,
+      granted_by    INT         NULL,
+      granted_at    DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      expires_at    DATETIME    NULL,
+      UNIQUE KEY uniq_user_perm (uid, permission_id, effect, resource_type, resource_id),
+      INDEX idx_uid (uid),
+      INDEX idx_resource (resource_type, resource_id),
+      CONSTRAINT fk_up_perm FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+};
+
+const syncPermissions = async () => {
+  for (const [key, meta] of Object.entries(PERMISSIONS)) {
+    await db.query(
+      `INSERT INTO permissions (\`key\`, \`group\`, name, description, scopable)
+       VALUES (?,?,?,?,?)
+       ON DUPLICATE KEY UPDATE \`group\`=VALUES(\`group\`), name=VALUES(name),
+                               description=VALUES(description), scopable=VALUES(scopable)`,
+      [key, meta.group, meta.name, meta.description || null, meta.scopable ? 1 : 0]
+    );
+  }
+};
+
+const syncBuiltinRoles = async () => {
+  const permRows = await db.query('SELECT id, `key` FROM permissions');
+  const permIdByKey = new Map(permRows.map((r) => [r.key, r.id]));
+
+  for (const [key, meta] of Object.entries(BUILTIN_ROLES)) {
+    await db.query(
+      `INSERT INTO roles (\`key\`, name, description, builtin, legacy_gid)
+       VALUES (?,?,?,1,?)
+       ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description),
+                               builtin=1, legacy_gid=VALUES(legacy_gid)`,
+      [key, meta.name, meta.description || null, meta.legacy_gid]
+    );
+    const role = await db.one('SELECT id FROM roles WHERE `key`=?', [key]);
+
+    // Reset permissions for builtin roles to keep them in sync with code.
+    await db.query('DELETE FROM role_permissions WHERE role_id=?', [role.id]);
+    if (meta.permissions.length) {
+      const values = meta.permissions
+        .map((pk) => permIdByKey.get(pk))
+        .filter((id) => id != null)
+        .map((pid) => [role.id, pid]);
+      if (values.length) {
+        await db.query('INSERT INTO role_permissions (role_id, permission_id) VALUES ?', [values]);
+      }
+    }
+  }
+};
+
+// One-time backfill: assign builtin role to existing users based on their gid.
+// Idempotent (PRIMARY KEY (uid, role_id) prevents duplicates).
+const backfillUserRoles = async () => {
+  const roleByGid = await db.query('SELECT id, legacy_gid FROM roles WHERE legacy_gid IS NOT NULL');
+  for (const r of roleByGid) {
+    await db.query(
+      `INSERT IGNORE INTO user_roles (uid, role_id, granted_by)
+       SELECT uid, ?, NULL FROM userInfo WHERE gid=?`,
+      [r.id, r.legacy_gid]
+    );
+  }
+};
+
+const syncPermissionCatalog = async () => {
+  await ensureSchema();
+  await syncPermissions();
+  await syncBuiltinRoles();
+  await backfillUserRoles();
+};
+
+module.exports = { syncPermissionCatalog };


### PR DESCRIPTION
## Summary

第一阶段重构权限系统，引入 RBAC 基础设施，**不改变任何现有行为**：

- 新表：`permissions` / `roles` / `role_permissions` / `user_roles` / `user_permissions`，启动时 `CREATE TABLE IF NOT EXISTS` 自动建表
- 权限目录与内置角色由代码定义（[server/auth/permissions.js](server/auth/permissions.js)），启动时 upsert 到 DB；内置角色 `user` / `problem_setter` / `contest_manager` / `judge_admin` / `moderator` / `super_admin`
- gid → role 回填：`legacy_gid` 字段把 1/2/3 映射到 `user` / `moderator` / `super_admin`，启动时为现有用户自动写入 `user_roles`
- `policy.loadEffectivePermissions` 计算 (global, denies, scoped)，60s 进程缓存
- `attachPermissions` 中间件挂 `req.perms` / `req.can(key, scope?)`
- `/api/admin/*` 全局拦截改成 `req.can('user.list')`（对回填后的 super_admin 用户等价）
- `getUserInfo` 返回 `permissions[]` 数组，前端后续可直接消费

未做（留给后续 PR）：

- PR 2：`/api/auth/*` 接口 + `/admin/permissions` 管理中心 + 通用组件
- PR 3：题目/比赛页内的协作者管理 + 调用点替换（`requireRole` / `gid` 比较 → `requirePermission` / `$can`）

## Test plan

- [ ] 启动服务，确认 5 张新表被创建：`SELECT * FROM permissions; SELECT * FROM roles;`
- [ ] 检查 `role_permissions`：内置角色权限被正确写入
- [ ] 检查 `user_roles`：所有现有用户根据 gid 各自写入了对应角色
- [ ] 重启服务，确认重复运行不会出错（幂等）
- [ ] 现有功能完全无感：`gid=2` 用户能正常出题，`gid=3` 用户能进入 `/api/admin/*`，`gid=1` 用户照常使用
- [ ] `getUserInfo` 接口返回中包含 `permissions` 字段

🤖 Generated with [Claude Code](https://claude.com/claude-code)