### PR TITLE
feat: permission management API + admin UI (PR 2/3)

### DIFF
--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -1,0 +1,324 @@
+const db = require('../db');
+const { handler, fail, ok } = require('../db/util');
+const { recordEvent } = require('../static');
+const policy = require('../auth/policy');
+const { PERMISSIONS, RESOURCE_TYPES, RESOURCE_GRANTABLE } = require('../auth/permissions');
+
+const KEY_REGEX = /^[a-z][a-z0-9_]{0,30}[a-z0-9]$/;
+
+const requireAny = (req, ...keys) => keys.some((k) => req.can(k));
+
+// ---------- read endpoints ----------
+
+exports.listPermissions = handler(async (req, res) => {
+  if (!requireAny(req, 'user.role.assign', 'user.permission.grant'))
+    return res.status(403).end('403 Forbidden');
+  const rows = await db.query(
+    'SELECT `key`, `group`, name, description, scopable FROM permissions ORDER BY `group`, `key`'
+  );
+  return ok(res, { permissions: rows });
+});
+
+exports.listRoles = handler(async (req, res) => {
+  if (!requireAny(req, 'user.role.assign', 'user.permission.grant'))
+    return res.status(403).end('403 Forbidden');
+  const roles = await db.query(
+    'SELECT id, `key`, name, description, builtin, legacy_gid FROM roles ORDER BY builtin DESC, id'
+  );
+  const links = await db.query(
+    `SELECT rp.role_id, p.\`key\` AS permission_key
+     FROM role_permissions rp JOIN permissions p ON p.id = rp.permission_id`
+  );
+  const byRole = new Map();
+  for (const l of links) {
+    if (!byRole.has(l.role_id)) byRole.set(l.role_id, []);
+    byRole.get(l.role_id).push(l.permission_key);
+  }
+  for (const r of roles) r.permissions = byRole.get(r.id) || [];
+  return ok(res, { roles });
+});
+
+// ---------- role management ----------
+
+const setRolePermissions = async (roleId, permKeys) => {
+  await db.query('DELETE FROM role_permissions WHERE role_id=?', [roleId]);
+  if (!permKeys.length) return;
+  const rows = await db.query('SELECT id, `key` FROM permissions WHERE `key` IN (?)', [permKeys]);
+  if (rows.length !== permKeys.length) {
+    const known = new Set(rows.map((r) => r.key));
+    const unknown = permKeys.filter((k) => !known.has(k));
+    throw new Error('未知权限: ' + unknown.join(','));
+  }
+  const values = rows.map((r) => [roleId, r.id]);
+  await db.query('INSERT INTO role_permissions (role_id, permission_id) VALUES ?', [values]);
+};
+
+exports.createRole = handler(async (req, res) => {
+  if (!req.can('user.role.assign')) return res.status(403).end('403 Forbidden');
+  const { key, name, description, permissionKeys } = req.body;
+  if (!key || !name) return fail(res, '请确认信息完善');
+  if (!KEY_REGEX.test(key)) return fail(res, '角色 key 格式非法（小写字母/数字/下划线）');
+  const exist = await db.exists('SELECT id FROM roles WHERE `key`=?', [key]);
+  if (exist) return fail(res, '该角色 key 已存在');
+  const r = await db.query(
+    'INSERT INTO roles (`key`, name, description, builtin, legacy_gid) VALUES (?,?,?,0,NULL)',
+    [key, name, description || null]
+  );
+  await setRolePermissions(r.insertId, permissionKeys || []);
+  recordEvent(req, 'auth.createRole', { key, name, permissionKeys });
+  return ok(res, { id: r.insertId });
+});
+
+exports.updateRole = handler(async (req, res) => {
+  if (!req.can('user.role.assign')) return res.status(403).end('403 Forbidden');
+  const { key, name, description, permissionKeys } = req.body;
+  if (!key) return fail(res, '请确认信息完善');
+  const role = await db.one('SELECT id, builtin FROM roles WHERE `key`=?', [key]);
+  if (!role) return fail(res, '角色不存在');
+  if (role.builtin) return fail(res, '内置角色不可修改');
+  if (name != null || description != null) {
+    await db.query(
+      'UPDATE roles SET name=COALESCE(?,name), description=COALESCE(?,description) WHERE id=?',
+      [name || null, description == null ? null : description, role.id]
+    );
+  }
+  if (Array.isArray(permissionKeys)) {
+    await setRolePermissions(role.id, permissionKeys);
+  }
+  // Affected users' caches are wide; broad invalidation is acceptable here.
+  policy.invalidate();
+  recordEvent(req, 'auth.updateRole', { key, name, permissionKeys });
+  return ok(res);
+});
+
+exports.deleteRole = handler(async (req, res) => {
+  if (!req.can('user.role.assign')) return res.status(403).end('403 Forbidden');
+  const { key } = req.body;
+  if (!key) return fail(res, '请确认信息完善');
+  const role = await db.one('SELECT id, builtin FROM roles WHERE `key`=?', [key]);
+  if (!role) return fail(res, '角色不存在');
+  if (role.builtin) return fail(res, '内置角色不可删除');
+  const inUse = await db.exists('SELECT 1 FROM user_roles WHERE role_id=? LIMIT 1', [role.id]);
+  if (inUse) return fail(res, '仍有用户持有此角色，请先解除');
+  await db.query('DELETE FROM roles WHERE id=?', [role.id]);
+  policy.invalidate();
+  recordEvent(req, 'auth.deleteRole', { key });
+  return ok(res);
+});
+
+// ---------- user grants ----------
+
+exports.listUserGrants = handler(async (req, res) => {
+  if (!requireAny(req, 'user.role.assign', 'user.permission.grant'))
+    return res.status(403).end('403 Forbidden');
+  const uid = parseInt(req.body.uid, 10);
+  if (!uid) return fail(res, '请确认信息完善');
+
+  const target = await db.one('SELECT uid, name, gid FROM userInfo WHERE uid=?', [uid]);
+  if (!target) return fail(res, '用户不存在');
+
+  const roles = await db.column(
+    `SELECT r.\`key\` AS k FROM user_roles ur JOIN roles r ON r.id = ur.role_id WHERE ur.uid=?`,
+    [uid],
+    'k'
+  );
+
+  const permissions = await db.query(
+    `SELECT up.id, p.\`key\` AS permissionKey, up.effect,
+            up.resource_type AS resourceType, up.resource_id AS resourceId,
+            up.granted_by AS grantedBy, up.granted_at AS grantedAt, up.expires_at AS expiresAt
+     FROM user_permissions up JOIN permissions p ON p.id = up.permission_id
+     WHERE up.uid=? ORDER BY up.id DESC`,
+    [uid]
+  );
+
+  return ok(res, { user: target, roles, permissions });
+});
+
+exports.setUserRoles = handler(async (req, res) => {
+  if (!req.can('user.role.assign')) return res.status(403).end('403 Forbidden');
+  const uid = parseInt(req.body.uid, 10);
+  const roleKeys = Array.isArray(req.body.roleKeys) ? req.body.roleKeys : null;
+  if (!uid || !roleKeys) return fail(res, '请确认信息完善');
+
+  const target = await db.exists('SELECT 1 FROM userInfo WHERE uid=?', [uid]);
+  if (!target) return fail(res, '用户不存在');
+
+  let roleRows = [];
+  if (roleKeys.length) {
+    roleRows = await db.query('SELECT id, `key` FROM roles WHERE `key` IN (?)', [roleKeys]);
+    if (roleRows.length !== roleKeys.length) {
+      const known = new Set(roleRows.map((r) => r.key));
+      const unknown = roleKeys.filter((k) => !known.has(k));
+      return fail(res, '未知角色: ' + unknown.join(','));
+    }
+  }
+
+  await db.tx(async (t) => {
+    await t.query('DELETE FROM user_roles WHERE uid=?', [uid]);
+    if (roleRows.length) {
+      const values = roleRows.map((r) => [uid, r.id, req.session.uid || null]);
+      await t.query('INSERT INTO user_roles (uid, role_id, granted_by) VALUES ?', [values]);
+    }
+  });
+
+  policy.invalidate(uid);
+  recordEvent(req, 'auth.setUserRoles', { uid, roleKeys });
+  return ok(res);
+});
+
+// Resource-owner check: can the current user authorize this scoped grant without holding
+// the global user.permission.grant permission?
+const canManageResource = async (req, resourceType, resourceId) => {
+  if (req.can('user.permission.grant')) return true;
+  if (!resourceType || resourceId == null) return false;
+  if (resourceType === 'problem') {
+    const row = await db.one('SELECT publisher FROM problem WHERE pid=?', [resourceId]);
+    if (!row) return false;
+    if (row.publisher === req.session.uid) return true;
+    return req.can('problem.edit.any', { type: 'problem', id: resourceId });
+  }
+  if (resourceType === 'contest') {
+    const row = await db.one('SELECT host FROM contest WHERE cid=?', [resourceId]);
+    if (!row) return false;
+    if (row.host === req.session.uid) return true;
+    return req.can('contest.edit.any', { type: 'contest', id: resourceId });
+  }
+  return false;
+};
+
+exports.grantUserPermission = handler(async (req, res) => {
+  const uid = parseInt(req.body.uid, 10);
+  const { permissionKey, effect, resourceType, expiresAt } = req.body;
+  const resourceId = req.body.resourceId == null ? null : parseInt(req.body.resourceId, 10);
+  if (!uid || !permissionKey || !effect) return fail(res, '请确认信息完善');
+  if (effect !== 'allow' && effect !== 'deny') return fail(res, 'effect 只能是 allow 或 deny');
+
+  const isScoped = !!(resourceType && resourceId != null);
+  if (resourceType && !RESOURCE_TYPES.includes(resourceType))
+    return fail(res, '不支持的资源类型');
+  if (!isScoped && (resourceType || resourceId != null))
+    return fail(res, 'resourceType 与 resourceId 必须同时提供');
+
+  // Authorization: global grant requires user.permission.grant; scoped grant also accepts
+  // resource owner / *.edit.any holders, but only for whitelisted permissions.
+  if (isScoped) {
+    if (!(await canManageResource(req, resourceType, resourceId)))
+      return res.status(403).end('403 Forbidden');
+    if (!req.can('user.permission.grant')) {
+      const allowed = RESOURCE_GRANTABLE[resourceType] || [];
+      if (!allowed.includes(permissionKey))
+        return fail(res, '资源所有者不可授予此权限');
+      if (effect !== 'allow')
+        return fail(res, '资源所有者只能授予允许（allow）权限');
+    }
+  } else if (!req.can('user.permission.grant')) {
+    return res.status(403).end('403 Forbidden');
+  }
+
+  const perm = await db.one('SELECT id, scopable FROM permissions WHERE `key`=?', [permissionKey]);
+  if (!perm) return fail(res, '未知权限');
+  if (isScoped && !perm.scopable) return fail(res, '该权限不支持资源级作用域');
+
+  const target = await db.exists('SELECT 1 FROM userInfo WHERE uid=?', [uid]);
+  if (!target) return fail(res, '用户不存在');
+
+  const expires = expiresAt ? new Date(expiresAt) : null;
+
+  // Upsert by UNIQUE KEY (uid, permission_id, effect, resource_type, resource_id).
+  await db.query(
+    `INSERT INTO user_permissions
+       (uid, permission_id, effect, resource_type, resource_id, granted_by, expires_at)
+     VALUES (?,?,?,?,?,?,?)
+     ON DUPLICATE KEY UPDATE
+       granted_by=VALUES(granted_by), expires_at=VALUES(expires_at), granted_at=CURRENT_TIMESTAMP`,
+    [
+      uid,
+      perm.id,
+      effect,
+      isScoped ? resourceType : null,
+      isScoped ? resourceId : null,
+      req.session.uid || null,
+      expires,
+    ]
+  );
+
+  policy.invalidate(uid);
+  recordEvent(req, 'auth.grantUserPermission', {
+    uid, permissionKey, effect,
+    resourceType: isScoped ? resourceType : null,
+    resourceId: isScoped ? resourceId : null,
+    expiresAt: expires,
+  });
+  return ok(res);
+});
+
+exports.revokeUserPermission = handler(async (req, res) => {
+  const id = parseInt(req.body.id, 10);
+  if (!id) return fail(res, '请确认信息完善');
+
+  const row = await db.one(
+    `SELECT up.uid, up.resource_type AS resourceType, up.resource_id AS resourceId,
+            p.\`key\` AS permissionKey
+     FROM user_permissions up JOIN permissions p ON p.id = up.permission_id
+     WHERE up.id=?`,
+    [id]
+  );
+  if (!row) return fail(res, '记录不存在');
+
+  // Auth: global record requires user.permission.grant; scoped record also accepts owner.
+  const isScoped = !!(row.resourceType && row.resourceId != null);
+  if (!req.can('user.permission.grant')) {
+    if (!isScoped) return res.status(403).end('403 Forbidden');
+    if (!(await canManageResource(req, row.resourceType, row.resourceId)))
+      return res.status(403).end('403 Forbidden');
+  }
+
+  await db.query('DELETE FROM user_permissions WHERE id=?', [id]);
+  policy.invalidate(row.uid);
+  recordEvent(req, 'auth.revokeUserPermission', { id, ...row });
+  return ok(res);
+});
+
+exports.listResourceGrants = handler(async (req, res) => {
+  const { resourceType } = req.body;
+  const resourceId = parseInt(req.body.resourceId, 10);
+  if (!resourceType || !resourceId) return fail(res, '请确认信息完善');
+  if (!RESOURCE_TYPES.includes(resourceType)) return fail(res, '不支持的资源类型');
+
+  if (!(await canManageResource(req, resourceType, resourceId)))
+    return res.status(403).end('403 Forbidden');
+
+  const rows = await db.query(
+    `SELECT up.id, up.uid, u.name, p.\`key\` AS permissionKey, up.effect,
+            up.expires_at AS expiresAt, up.granted_at AS grantedAt
+     FROM user_permissions up
+     JOIN permissions p ON p.id = up.permission_id
+     JOIN userInfo u ON u.uid = up.uid
+     WHERE up.resource_type=? AND up.resource_id=?
+     ORDER BY up.id DESC`,
+    [resourceType, resourceId]
+  );
+
+  const grantable = RESOURCE_GRANTABLE[resourceType] || [];
+  return ok(res, { grants: rows, grantablePermissions: grantable });
+});
+
+// Helper for the user picker on the management page.
+exports.searchUsers = handler(async (req, res) => {
+  if (!requireAny(req, 'user.role.assign', 'user.permission.grant'))
+    return res.status(403).end('403 Forbidden');
+  const q = (req.body.q || '').trim();
+  if (!q) return ok(res, { users: [] });
+  const isNumeric = /^\d+$/.test(q);
+  const rows = await db.query(
+    `SELECT uid, name FROM userInfo
+     WHERE ${isNumeric ? 'uid=? OR name LIKE ?' : 'name LIKE ?'}
+     ORDER BY uid LIMIT 20`,
+    isNumeric ? [parseInt(q, 10), `%${q}%`] : [`%${q}%`]
+  );
+  return ok(res, { users: rows });
+});
+
+// expose for sanity tests
+exports._catalog = { PERMISSIONS };

--- a/server/router.js
+++ b/server/router.js
@@ -33,6 +33,20 @@ router.post('/api/admin/updateUserInfo', admin.updateUserInfo);
 router.post('/api/admin/addAnnouncement', admin.addAnnouncement);
 router.post('/api/admin/updateAnnouncement', admin.updateAnnouncement);
 
+const auth = require('./api/auth');
+
+router.post('/api/auth/listPermissions', auth.listPermissions);
+router.post('/api/auth/listRoles', auth.listRoles);
+router.post('/api/auth/createRole', auth.createRole);
+router.post('/api/auth/updateRole', auth.updateRole);
+router.post('/api/auth/deleteRole', auth.deleteRole);
+router.post('/api/auth/listUserGrants', auth.listUserGrants);
+router.post('/api/auth/setUserRoles', auth.setUserRoles);
+router.post('/api/auth/grantUserPermission', auth.grantUserPermission);
+router.post('/api/auth/revokeUserPermission', auth.revokeUserPermission);
+router.post('/api/auth/listResourceGrants', auth.listResourceGrants);
+router.post('/api/auth/searchUsers', auth.searchUsers);
+
 const problem = require('./api/problem');
 
 router.post('/api/problem/createProblem', problem.createProblem);

--- a/server/static.js
+++ b/server/static.js
@@ -72,6 +72,12 @@ exports.eventList = [
   'problem.updateCase',
   'problem.downloadCase',
   'problem.updateConfig',
+  'auth.setUserRoles',
+  'auth.grantUserPermission',
+  'auth.revokeUserPermission',
+  'auth.createRole',
+  'auth.updateRole',
+  'auth.deleteRole',
 ];
 
 exports.eventExp = [
@@ -89,6 +95,12 @@ exports.eventExp = [
   '修改测试数据',
   '下载测试数据',
   '修改题目配置',
+  '设置用户角色',
+  '授予用户权限',
+  '撤销用户权限',
+  '创建角色',
+  '更新角色',
+  '删除角色',
 ]
 
 

--- a/web/src/assets/common.js
+++ b/web/src/assets/common.js
@@ -57,6 +57,7 @@ export const refreshUserInfo = async () => {
       store.state.ip = res.data.ip;
       store.state.avatar = res.data.avatar;
       store.state.preferenceLang = res.data.preferenceLang;
+      store.commit('setPermissions', res.data.permissions || []);
     }
   });
 }

--- a/web/src/components/admin/permissionCenter.vue
+++ b/web/src/components/admin/permissionCenter.vue
@@ -1,0 +1,240 @@
+<template>
+  <div style="margin: 10px auto; max-width: 1200px;">
+    <el-card shadow="hover" v-loading="loading">
+      <template #header>
+        <div class="card-header">
+          <span>权限管理中心</span>
+          <el-button type="primary" plain @click="reloadAll">刷新</el-button>
+        </div>
+      </template>
+
+      <el-tabs v-model="activeTab">
+        <!-- A2: 用户授权 -->
+        <el-tab-pane label="用户授权" name="userGrants">
+          <el-form :inline="true">
+            <el-form-item label="选择用户">
+              <UserPicker v-model="pickedUid" style="width: 320px;" @change="onUserPicked" />
+            </el-form-item>
+            <el-form-item v-if="pickedUid">
+              <el-button @click="loadUserGrants">重新加载</el-button>
+            </el-form-item>
+          </el-form>
+
+          <div v-if="!pickedUid" style="color:#909399; padding: 20px;">请选择一个用户。</div>
+
+          <div v-else>
+            <el-descriptions :column="3" border>
+              <el-descriptions-item label="uid">{{ userInfo.uid }}</el-descriptions-item>
+              <el-descriptions-item label="用户名">{{ userInfo.name }}</el-descriptions-item>
+              <el-descriptions-item label="主 gid">{{ userInfo.gid }}</el-descriptions-item>
+            </el-descriptions>
+
+            <el-divider>角色</el-divider>
+            <el-checkbox-group v-model="userRoleKeys">
+              <el-checkbox
+                v-for="r in roles"
+                :key="r.key"
+                :label="r.key"
+                :disabled="!canAssignRoles"
+              >
+                <span>{{ r.name }}</span>
+                <el-tag size="small" v-if="r.builtin" style="margin-left:6px">内置</el-tag>
+                <span style="color:#909399;font-size:12px;margin-left:4px;">({{ r.key }})</span>
+              </el-checkbox>
+            </el-checkbox-group>
+            <div style="margin-top: 10px;">
+              <el-button type="primary" :disabled="!canAssignRoles || rolesDirty === false" :loading="savingRoles" @click="saveRoles">保存角色</el-button>
+              <span v-if="rolesDirty" style="color:#e6a23c; margin-left: 8px;">已修改未保存</span>
+            </div>
+
+            <el-divider>直接授权</el-divider>
+            <GrantTable
+              v-if="canGrantPerm"
+              :uid="userInfo.uid"
+              :grants="userPermissions"
+              :permissions="permissions"
+              @changed="loadUserGrants"
+            />
+            <div v-else style="color:#909399;">需要 user.permission.grant 权限以管理直接授权。</div>
+          </div>
+        </el-tab-pane>
+
+        <!-- A1: 角色管理 -->
+        <el-tab-pane label="角色管理" name="roles">
+          <div style="margin-bottom: 10px;">
+            <el-button type="primary" :disabled="!canAssignRoles" @click="openCreateRole">+ 新建角色</el-button>
+          </div>
+          <el-table :data="roles" :cell-style="{ textAlign: 'center' }" :header-cell-style="{ textAlign: 'center' }">
+            <el-table-column label="key" prop="key" width="180" />
+            <el-table-column label="名称" prop="name" width="160" />
+            <el-table-column label="说明" prop="description" />
+            <el-table-column label="类型" width="100">
+              <template #default="scope">
+                <el-tag size="small" v-if="scope.row.builtin">内置</el-tag>
+                <el-tag size="small" type="info" v-else>自定义</el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column label="legacy gid" width="110" prop="legacy_gid" />
+            <el-table-column label="权限数" width="90">
+              <template #default="scope">{{ (scope.row.permissions || []).length }}</template>
+            </el-table-column>
+            <el-table-column label="操作" width="200">
+              <template #default="scope">
+                <el-button size="small" plain @click="openEditRole(scope.row)" :disabled="scope.row.builtin || !canAssignRoles">编辑</el-button>
+                <el-button size="small" plain type="danger" :disabled="scope.row.builtin || !canAssignRoles" @click="deleteRole(scope.row)">删除</el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+
+          <RoleEditor
+            v-model="roleEditorVisible"
+            :role="editingRole"
+            :permissions="permissions"
+            @saved="onRoleSaved"
+          />
+        </el-tab-pane>
+
+        <!-- A3: 权限目录 -->
+        <el-tab-pane label="权限目录" name="catalog">
+          <el-table :data="permissions" :cell-style="{ textAlign: 'center' }" :header-cell-style="{ textAlign: 'center' }">
+            <el-table-column label="分组" prop="group" width="100" />
+            <el-table-column label="key" prop="key" width="260" />
+            <el-table-column label="名称" prop="name" width="180" />
+            <el-table-column label="说明" prop="description" />
+            <el-table-column label="可作用域" width="100">
+              <template #default="scope">
+                <el-tag size="small" v-if="scope.row.scopable" type="success">可</el-tag>
+                <el-tag size="small" v-else type="info">否</el-tag>
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-tab-pane>
+      </el-tabs>
+    </el-card>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+import { ElMessageBox } from 'element-plus';
+import UserPicker from '@/components/permission/UserPicker.vue';
+import GrantTable from '@/components/permission/GrantTable.vue';
+import RoleEditor from '@/components/permission/RoleEditor.vue';
+import { can } from '@/utils/can';
+
+export default {
+  name: 'PermissionCenter',
+  components: { UserPicker, GrantTable, RoleEditor },
+  data() {
+    return {
+      loading: false,
+      activeTab: 'userGrants',
+      permissions: [],
+      roles: [],
+      pickedUid: null,
+      userInfo: { uid: 0, name: '', gid: 0 },
+      userRoleKeys: [],
+      originalRoleKeys: [],
+      userPermissions: [],
+      savingRoles: false,
+      roleEditorVisible: false,
+      editingRole: null,
+    };
+  },
+  computed: {
+    canAssignRoles() { return can('user.role.assign'); },
+    canGrantPerm() { return can('user.permission.grant'); },
+    rolesDirty() {
+      const a = [...this.userRoleKeys].sort();
+      const b = [...this.originalRoleKeys].sort();
+      if (a.length !== b.length) return true;
+      return a.some((k, i) => k !== b[i]);
+    },
+  },
+  async mounted() {
+    const q = this.$route.query || {};
+    if (q.tab) this.activeTab = q.tab;
+    await this.reloadAll();
+    if (q.uid) {
+      this.pickedUid = parseInt(q.uid, 10);
+      await this.loadUserGrants();
+    }
+  },
+  methods: {
+    async reloadAll() {
+      this.loading = true;
+      try {
+        const [pr, rr] = await Promise.all([
+          axios.post('/api/auth/listPermissions'),
+          axios.post('/api/auth/listRoles'),
+        ]);
+        this.permissions = (pr.data && pr.data.permissions) || [];
+        this.roles = (rr.data && rr.data.roles) || [];
+      } catch (e) {
+        this.$message.error(e.message || '加载失败');
+      } finally {
+        this.loading = false;
+      }
+    },
+    onUserPicked(picked) {
+      if (picked) this.loadUserGrants();
+      else { this.userInfo = { uid: 0, name: '', gid: 0 }; this.userRoleKeys = []; this.userPermissions = []; }
+    },
+    async loadUserGrants() {
+      if (!this.pickedUid) return;
+      try {
+        const res = await axios.post('/api/auth/listUserGrants', { uid: this.pickedUid });
+        if (res.status !== 200) { this.$message.error(res.data && res.data.message || '加载失败'); return; }
+        this.userInfo = res.data.user || { uid: this.pickedUid, name: '', gid: 0 };
+        this.userRoleKeys = res.data.roles || [];
+        this.originalRoleKeys = [...this.userRoleKeys];
+        this.userPermissions = res.data.permissions || [];
+      } catch (e) {
+        this.$message.error(e.message || '加载失败');
+      }
+    },
+    async saveRoles() {
+      this.savingRoles = true;
+      try {
+        const res = await axios.post('/api/auth/setUserRoles', {
+          uid: this.userInfo.uid,
+          roleKeys: this.userRoleKeys,
+        });
+        if (res.status === 200) {
+          this.$message.success('已保存');
+          this.originalRoleKeys = [...this.userRoleKeys];
+        } else {
+          this.$message.error(res.data && res.data.message || '保存失败');
+        }
+      } catch (e) {
+        this.$message.error(e.message || '保存失败');
+      } finally {
+        this.savingRoles = false;
+      }
+    },
+    openCreateRole() { this.editingRole = null; this.roleEditorVisible = true; },
+    openEditRole(role) { this.editingRole = role; this.roleEditorVisible = true; },
+    async onRoleSaved() { await this.reloadAll(); },
+    async deleteRole(role) {
+      try {
+        await ElMessageBox.confirm(`确认删除自定义角色 ${role.key}？`, '提示', { type: 'warning' });
+      } catch (_) { return; }
+      try {
+        const res = await axios.post('/api/auth/deleteRole', { key: role.key });
+        if (res.status === 200) { this.$message.success('已删除'); await this.reloadAll(); }
+        else this.$message.error(res.data && res.data.message || '删除失败');
+      } catch (e) {
+        this.$message.error(e.message || '删除失败');
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/web/src/components/admin/userManage.vue
+++ b/web/src/components/admin/userManage.vue
@@ -98,7 +98,7 @@
             <span> {{ scope.row.inUse ? "正常" : "封禁" }}</span>
           </template>
         </el-table-column>
-        <el-table-column fixed="right" width="250px">
+        <el-table-column fixed="right" width="360px">
           <template #header>
             <div class="table-header">
               操作
@@ -117,6 +117,10 @@
               <el-button size="small" :type="scope.row.inUse ? 'danger' : 'success'" plain
                 @click="setBlock(scope.row.uid, !scope.row.inUse)">
                 {{ scope.row.inUse ? "封禁账号" : "解除封禁" }}
+              </el-button>
+              <el-button size="small" type="info" plain v-if="$canAny('user.role.assign','user.permission.grant')"
+                @click="openPermission(scope.row.uid)">
+                角色权限
               </el-button>
             </span>
           </template>
@@ -248,7 +252,10 @@ export default {
         };
       }
       row.edit ^= 1;
-    }
+    },
+    openPermission(uid) {
+      this.$router.push({ path: '/admin/permissions', query: { tab: 'userGrants', uid } });
+    },
   },
   mounted() {
     let query = this.$route.query;

--- a/web/src/components/myHeader.vue
+++ b/web/src/components/myHeader.vue
@@ -62,6 +62,12 @@
         </el-icon>
         用户管理
       </el-menu-item>
+      <el-menu-item v-if="$canAny('user.role.assign','user.permission.grant')" index="/admin/permissions">
+        <el-icon>
+          <Lock />
+        </el-icon>
+        权限管理
+      </el-menu-item>
       <el-menu-item index="/paste">
         <el-icon>
           <Document />

--- a/web/src/components/permission/GrantTable.vue
+++ b/web/src/components/permission/GrantTable.vue
@@ -1,0 +1,171 @@
+<template>
+  <div>
+    <el-table :data="grants" :cell-style="{ textAlign: 'center' }" :header-cell-style="{ textAlign: 'center' }">
+      <el-table-column label="权限" prop="permissionKey">
+        <template #default="scope">
+          <el-tag size="small">{{ permName(scope.row.permissionKey) }}</el-tag>
+          <div style="font-size: 12px; color: #909399;">{{ scope.row.permissionKey }}</div>
+        </template>
+      </el-table-column>
+      <el-table-column label="效果" width="100">
+        <template #default="scope">
+          <el-tag :type="scope.row.effect === 'deny' ? 'danger' : 'success'" size="small">
+            {{ scope.row.effect === 'deny' ? '拒绝' : '允许' }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="资源作用域" width="180">
+        <template #default="scope">
+          <span v-if="scope.row.resourceType">
+            {{ scope.row.resourceType }} #{{ scope.row.resourceId }}
+          </span>
+          <span v-else style="color:#909399">全局</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="过期时间" width="180">
+        <template #default="scope">
+          <span v-if="scope.row.expiresAt">{{ formatDate(scope.row.expiresAt) }}</span>
+          <span v-else style="color:#909399">永久</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="100">
+        <template #default="scope">
+          <el-button type="danger" size="small" plain @click="onRevoke(scope.row)">撤销</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-divider>新增授权</el-divider>
+
+    <el-form :inline="true" :model="form" @submit.prevent="onGrant">
+      <el-form-item label="权限">
+        <PermissionPicker
+          v-model="form.permissionKey"
+          :permissions="permissions"
+          :whitelist="whitelist"
+          :scopable-only="scopedOnly"
+          placeholder="选择权限"
+          style="width: 240px;"
+        />
+      </el-form-item>
+      <el-form-item label="效果" v-if="!scopedOnly || allowDeny">
+        <el-select v-model="form.effect" style="width: 100px;">
+          <el-option label="允许" value="allow" />
+          <el-option label="拒绝" value="deny" />
+        </el-select>
+      </el-form-item>
+      <template v-if="!fixedScope">
+        <el-form-item label="资源类型">
+          <el-select v-model="form.resourceType" clearable placeholder="（全局）" style="width: 130px;">
+            <el-option label="题目" value="problem" />
+            <el-option label="比赛" value="contest" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="资源 ID" v-if="form.resourceType">
+          <el-input-number v-model="form.resourceId" :min="1" style="width: 130px;" />
+        </el-form-item>
+      </template>
+      <el-form-item label="过期">
+        <el-date-picker v-model="form.expiresAt" type="datetime" placeholder="（永久）" style="width: 200px;" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" :loading="granting" @click="onGrant">授予</el-button>
+      </el-form-item>
+    </el-form>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+import { ElMessageBox } from 'element-plus';
+import PermissionPicker from './PermissionPicker.vue';
+
+const formDefaults = (fixedScope) => ({
+  permissionKey: null,
+  effect: 'allow',
+  resourceType: fixedScope ? fixedScope.type : null,
+  resourceId: fixedScope ? fixedScope.id : null,
+  expiresAt: null,
+});
+
+export default {
+  name: 'GrantTable',
+  components: { PermissionPicker },
+  props: {
+    uid: { type: Number, required: true },
+    grants: { type: Array, required: true },
+    permissions: { type: Array, required: true },
+    whitelist: { type: Array, default: null },
+    fixedScope: { type: Object, default: null },     // { type, id } when used inside resource page
+    scopedOnly: { type: Boolean, default: false },   // hide non-scopable perms
+    allowDeny: { type: Boolean, default: true },
+  },
+  emits: ['changed'],
+  data() {
+    return { form: formDefaults(this.fixedScope), granting: false };
+  },
+  watch: {
+    fixedScope: {
+      handler(v) { this.form = formDefaults(v); },
+      deep: true,
+    },
+  },
+  methods: {
+    permName(key) {
+      const p = this.permissions.find((x) => x.key === key);
+      return p ? p.name : key;
+    },
+    formatDate(v) {
+      if (!v) return '';
+      const d = new Date(v);
+      if (Number.isNaN(d.getTime())) return v;
+      const pad = (n) => (n < 10 ? '0' + n : n);
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    },
+    async onGrant() {
+      if (!this.form.permissionKey) { this.$message.error('请选择权限'); return; }
+      if (this.form.resourceType && this.form.resourceId == null) {
+        this.$message.error('请填写资源 ID'); return;
+      }
+      this.granting = true;
+      try {
+        const res = await axios.post('/api/auth/grantUserPermission', {
+          uid: this.uid,
+          permissionKey: this.form.permissionKey,
+          effect: this.form.effect,
+          resourceType: this.form.resourceType || null,
+          resourceId: this.form.resourceType ? this.form.resourceId : null,
+          expiresAt: this.form.expiresAt || null,
+        });
+        if (res.status === 200) {
+          this.$message.success('授权成功');
+          this.form = formDefaults(this.fixedScope);
+          this.$emit('changed');
+        } else {
+          this.$message.error(res.data && res.data.message || '授权失败');
+        }
+      } catch (e) {
+        this.$message.error(e.message || '授权失败');
+      } finally {
+        this.granting = false;
+      }
+    },
+    async onRevoke(row) {
+      try {
+        await ElMessageBox.confirm('确认撤销此授权？', '提示', { type: 'warning' });
+      } catch (_) { return; }
+      try {
+        const res = await axios.post('/api/auth/revokeUserPermission', { id: row.id });
+        if (res.status === 200) {
+          this.$message.success('已撤销');
+          this.$emit('changed');
+        } else {
+          this.$message.error(res.data && res.data.message || '撤销失败');
+        }
+      } catch (e) {
+        this.$message.error(e.message || '撤销失败');
+      }
+    },
+  },
+};
+</script>

--- a/web/src/components/permission/PermissionPicker.vue
+++ b/web/src/components/permission/PermissionPicker.vue
@@ -1,0 +1,78 @@
+<template>
+  <el-select
+    v-model="selected"
+    :multiple="multiple"
+    :placeholder="placeholder"
+    :clearable="clearable"
+    filterable
+    style="width: 100%;"
+    @change="onChange"
+  >
+    <el-option-group v-for="g in groups" :key="g.name" :label="g.name">
+      <el-option
+        v-for="p in g.items"
+        :key="p.key"
+        :label="`${p.name} (${p.key})`"
+        :value="p.key"
+      />
+    </el-option-group>
+  </el-select>
+</template>
+
+<script>
+const GROUP_LABEL = {
+  problem: '题目',
+  contest: '比赛',
+  judge: '判题 / 提交',
+  user: '用户',
+  system: '系统',
+};
+
+export default {
+  name: 'PermissionPicker',
+  props: {
+    modelValue: { type: [String, Array, null], default: null },
+    permissions: { type: Array, required: true },     // [{ key, group, name, scopable }]
+    whitelist: { type: Array, default: null },        // null = no restriction
+    multiple: { type: Boolean, default: false },
+    scopableOnly: { type: Boolean, default: false },
+    clearable: { type: Boolean, default: true },
+    placeholder: { type: String, default: '选择权限' },
+  },
+  emits: ['update:modelValue', 'change'],
+  data() {
+    return { selected: this.modelValue };
+  },
+  computed: {
+    filtered() {
+      let list = this.permissions || [];
+      if (this.whitelist) {
+        const set = new Set(this.whitelist);
+        list = list.filter((p) => set.has(p.key));
+      }
+      if (this.scopableOnly) list = list.filter((p) => p.scopable);
+      return list;
+    },
+    groups() {
+      const map = new Map();
+      for (const p of this.filtered) {
+        const g = p.group || 'other';
+        if (!map.has(g)) map.set(g, []);
+        map.get(g).push(p);
+      }
+      return Array.from(map.entries()).map(([k, items]) => ({
+        key: k, name: GROUP_LABEL[k] || k, items,
+      }));
+    },
+  },
+  watch: {
+    modelValue(v) { this.selected = v; },
+  },
+  methods: {
+    onChange(v) {
+      this.$emit('update:modelValue', v);
+      this.$emit('change', v);
+    },
+  },
+};
+</script>

--- a/web/src/components/permission/RoleEditor.vue
+++ b/web/src/components/permission/RoleEditor.vue
@@ -1,0 +1,108 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    :title="isCreate ? '新建角色' : `编辑角色：${form.key}`"
+    width="640px"
+    @closed="onClosed"
+  >
+    <el-form :model="form" label-width="100px">
+      <el-form-item label="角色 key">
+        <el-input v-model="form.key" :disabled="!isCreate" placeholder="role_setter (小写字母/数字/下划线)" />
+      </el-form-item>
+      <el-form-item label="名称">
+        <el-input v-model="form.name" placeholder="出题人" />
+      </el-form-item>
+      <el-form-item label="说明">
+        <el-input v-model="form.description" type="textarea" :rows="2" />
+      </el-form-item>
+      <el-form-item label="包含权限">
+        <PermissionPicker
+          v-model="form.permissionKeys"
+          :permissions="permissions"
+          multiple
+          placeholder="勾选权限"
+        />
+      </el-form-item>
+    </el-form>
+    <template #footer>
+      <el-button @click="visible = false">取消</el-button>
+      <el-button type="primary" :loading="saving" @click="save">保存</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script>
+import axios from 'axios';
+import PermissionPicker from './PermissionPicker.vue';
+
+const emptyForm = () => ({ key: '', name: '', description: '', permissionKeys: [] });
+
+export default {
+  name: 'RoleEditor',
+  components: { PermissionPicker },
+  props: {
+    modelValue: { type: Boolean, default: false },
+    role: { type: Object, default: null },          // null = create
+    permissions: { type: Array, required: true },
+  },
+  emits: ['update:modelValue', 'saved'],
+  data() {
+    return { form: emptyForm(), saving: false };
+  },
+  computed: {
+    visible: {
+      get() { return this.modelValue; },
+      set(v) { this.$emit('update:modelValue', v); },
+    },
+    isCreate() { return !this.role; },
+  },
+  watch: {
+    modelValue(open) {
+      if (!open) return;
+      if (this.role) {
+        this.form = {
+          key: this.role.key,
+          name: this.role.name,
+          description: this.role.description || '',
+          permissionKeys: [...(this.role.permissions || [])],
+        };
+      } else {
+        this.form = emptyForm();
+      }
+    },
+  },
+  methods: {
+    onClosed() {
+      this.form = emptyForm();
+      this.saving = false;
+    },
+    async save() {
+      if (!this.form.key || !this.form.name) {
+        this.$message.error('请填写 key 和名称');
+        return;
+      }
+      this.saving = true;
+      try {
+        const url = this.isCreate ? '/api/auth/createRole' : '/api/auth/updateRole';
+        const res = await axios.post(url, {
+          key: this.form.key,
+          name: this.form.name,
+          description: this.form.description,
+          permissionKeys: this.form.permissionKeys,
+        });
+        if (res.status === 200) {
+          this.$message.success('保存成功');
+          this.$emit('saved');
+          this.visible = false;
+        } else {
+          this.$message.error(res.data && res.data.message || '保存失败');
+        }
+      } catch (e) {
+        this.$message.error(e.message || '保存失败');
+      } finally {
+        this.saving = false;
+      }
+    },
+  },
+};
+</script>

--- a/web/src/components/permission/UserPicker.vue
+++ b/web/src/components/permission/UserPicker.vue
@@ -1,0 +1,63 @@
+<template>
+  <el-select
+    v-model="selected"
+    filterable
+    remote
+    reserve-keyword
+    :placeholder="placeholder"
+    :remote-method="search"
+    :loading="loading"
+    :clearable="clearable"
+    style="width: 100%;"
+    @change="onChange"
+  >
+    <el-option
+      v-for="u in options"
+      :key="u.uid"
+      :label="`${u.name} (#${u.uid})`"
+      :value="u.uid"
+    />
+  </el-select>
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+  name: 'UserPicker',
+  props: {
+    modelValue: { type: [Number, null], default: null },
+    placeholder: { type: String, default: '搜索用户名或 uid' },
+    clearable: { type: Boolean, default: true },
+  },
+  emits: ['update:modelValue', 'change'],
+  data() {
+    return {
+      selected: this.modelValue,
+      options: [],
+      loading: false,
+    };
+  },
+  watch: {
+    modelValue(v) { this.selected = v; },
+  },
+  methods: {
+    async search(q) {
+      const query = (q || '').trim();
+      if (!query) { this.options = []; return; }
+      this.loading = true;
+      try {
+        const res = await axios.post('/api/auth/searchUsers', { q: query });
+        this.options = (res.data && res.data.users) || [];
+      } finally {
+        this.loading = false;
+      }
+    },
+    onChange(v) {
+      this.$emit('update:modelValue', v);
+      const picked = this.options.find((u) => u.uid === v) || null;
+      this.$emit('change', picked);
+    },
+  },
+};
+</script>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -80,4 +80,7 @@ for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
 import { ElMessage } from 'element-plus'
 app.config.globalProperties.$message = ElMessage
 
+import canPlugin from '@/utils/can'
+app.use(canPlugin)
+
 app.use(ElementPlus).use(ElMessage).use(router).use(store).use(VMdEditor).use(VMdPreview).mount('#app');

--- a/web/src/router/router.js
+++ b/web/src/router/router.js
@@ -27,6 +27,7 @@ import contestProblem from '@/components/contest/contestProblem.vue'
 import userEdit from '@/components/user/edit/userEdit.vue'
 
 import userManage from "@/components/admin/userManage"
+import permissionCenter from "@/components/admin/permissionCenter"
 
 import { refreshUserInfo } from '@/assets/common'
 import store from '@/sto/store';
@@ -34,6 +35,11 @@ import store from '@/sto/store';
 const per = [];
 
 per["/admin/usermanage"] = 3;
+
+// permission-based gates: route -> [required permission keys, any-of]
+const perPermissions = {
+  '/admin/permissions': ['user.role.assign', 'user.permission.grant'],
+};
 
 const router = createRouter({
     history: createWebHistory(),
@@ -61,6 +67,12 @@ const router = createRouter({
             activeTitle: '/user'
         },
         path: '/admin/usermanage', component: userManage,
+    }, {
+        meta: {
+            title: '权限管理中心',
+            activeTitle: '/user'
+        },
+        path: '/admin/permissions', component: permissionCenter,
     }, {
         meta: {
             title: '用户信息',
@@ -203,8 +215,10 @@ router.beforeEach(async (to, from, next) => {
         await refreshUserInfo();
     }
     if (store.state.uid) {
-        if (!per[to.path] || store.state.gid >= per[to.path])
-            next();
+        if (per[to.path] && store.state.gid < per[to.path]) return;
+        const need = perPermissions[to.path];
+        if (need && !need.some((k) => (store.state.permissions || []).indexOf(k) >= 0)) return;
+        next();
     }
     else {
         if (to.path !== '/user/login')

--- a/web/src/sto/store.js
+++ b/web/src/sto/store.js
@@ -11,8 +11,13 @@ export default createStore({
         reDirectTo: '/',
         langList: [],
         preferenceLang: null,
+        permissions: [],
     },
-    mutations: {},
+    mutations: {
+        setPermissions(state, list) {
+            state.permissions = Array.isArray(list) ? list : [];
+        },
+    },
     actions: {},
     modules: {}
 })

--- a/web/src/utils/can.js
+++ b/web/src/utils/can.js
@@ -1,0 +1,20 @@
+import store from '@/sto/store';
+
+// UI-only permission check. Server is always the final arbiter.
+// scope is { type, id } | undefined; scoped grants are fetched per-page on demand,
+// so for now `can` only inspects the global keys returned by getUserInfo.
+export const can = (key) => {
+  if (!key) return false;
+  const list = store.state.permissions || [];
+  return list.indexOf(key) >= 0;
+};
+
+export const canAny = (...keys) => keys.some((k) => can(k));
+
+// Mixin to expose this.$can(...) inside templates.
+export default {
+  install(app) {
+    app.config.globalProperties.$can = can;
+    app.config.globalProperties.$canAny = canAny;
+  },
+};


### PR DESCRIPTION
> 基于 [PR 1/3 #7](https://github.com/Baymin-ty/nywOJ/pull/7)，目标分支临时设为 PR1 分支以便独立审阅；PR1 合并后我会把 base 改成 main。

## Summary

- 服务端：新增 `/api/auth/*` 一整套接口，覆盖角色 CRUD、用户角色设置、用户级 grant/revoke（支持全局与资源级两种模式）、资源级授权列表与用户搜索
- 资源级授权特殊路径：题目/比赛 owner（或持有 `*.edit.any` 的人）可在不持有全局 `user.permission.grant` 的情况下，对自己的资源授予白名单内的权限给协作者；这是后续 PR3 的题目/比赛页内嵌「协作者」功能的接口基础
- 所有变更操作都写入 `userAudit` 并使 `policy` 缓存对该用户失效
- 前端：
  - `$can` / `$canAny` 全局方法 + store `permissions[]` 状态 + `refreshUserInfo` 自动写入
  - 新增 `/admin/permissions` 页面（**用户授权 / 角色管理 / 权限目录** 三个 Tab）
  - 复用组件：`UserPicker`、`PermissionPicker`（按 group 分组、支持白名单/scopable 过滤）、`GrantTable`（通用授权表格 + 添加/撤销）、`RoleEditor`（角色编辑弹窗）
  - 顶部导航栏在用户拥有 `user.role.assign` 或 `user.permission.grant` 时显示「权限管理」入口
  - 现有用户列表每行追加「角色权限」按钮，深链到 `/admin/permissions?tab=userGrants&uid=<uid>`

## Test plan

- [ ] 以 `gid=3` 用户登录，进入「权限管理」→「用户授权」，搜索一个普通用户，给其增加 `problem_setter` 角色 → 该用户应能创建题目（请用 PR3 完成调用点替换后再彻底测，或用接口测试）
- [ ] 在「直接授权」面板，给用户授予 `contest.create`（全局，allow）→ 撤销后失效（`policy.invalidate` 验证）
- [ ] 给用户授予 `contest.edit.any` 并设置 resourceType=`contest`、resourceId=42 → 后端 `loadEffectivePermissions` 把它放进 `scoped` 而非 `global`
- [ ] 「角色管理」Tab：创建一个自定义角色，勾选若干权限 → 列表展示；编辑、删除（无人持有时）正常
- [ ] 内置角色无法编辑/删除（按钮禁用）
- [ ] 不带 `user.role.assign` 与 `user.permission.grant` 的用户访问 `/admin/permissions` → 路由守卫拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)