### PR TITLE
feat: migrate permission checks + resource collaborator UI (PR 3/3)

### DIFF
--- a/server/api/admin.js
+++ b/server/api/admin.js
@@ -1,8 +1,9 @@
 const db = require('../db');
-const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
+const { handler, fail, ok, paginate, buildWhere } = require('../db/util');
+const { requirePermission } = require('../auth/middleware');
 
 exports.getUserInfoList = [
-  requireRole(3),
+  requirePermission('user.list'),
   handler(async (req, res) => {
     const { offset, limit } = paginate(req);
     const filter = req.body.filter || {};
@@ -27,7 +28,7 @@ exports.getUserInfoList = [
 ];
 
 exports.setBlock = [
-  requireRole(3),
+  requirePermission('user.ban'),
   handler(async (req, res) => {
     const { uid, status } = req.body;
     if (uid == null || status == null) return fail(res, '请确认信息完善');
@@ -38,7 +39,7 @@ exports.setBlock = [
 ];
 
 exports.updateUserInfo = [
-  requireRole(3),
+  requirePermission('user.edit'),
   handler(async (req, res) => {
     const info = req.body.info || {};
     const { uid, name, email, gid } = info;
@@ -53,7 +54,7 @@ exports.updateUserInfo = [
 ];
 
 exports.addAnnouncement = [
-  requireRole(3),
+  requirePermission('announcement.manage'),
   handler(async (req, res) => {
     const r = await db.query(
       'INSERT INTO announcement(title,description,weight,time) VALUES (?,?,?,?)',
@@ -65,7 +66,7 @@ exports.addAnnouncement = [
 ];
 
 exports.updateAnnouncement = [
-  requireRole(3),
+  requirePermission('announcement.manage'),
   handler(async (req, res) => {
     const info = req.body.info || {};
     const { aid, title, description, weight } = info;

--- a/server/api/common.js
+++ b/server/api/common.js
@@ -28,7 +28,7 @@ exports.getPaste = handler(async (req, res) => {
     [req.body.mark]
   );
   if (!row) return fail(res, '未找到');
-  if (req.session.gid < 3 && !row.isPublic && row.uid !== req.session.uid) {
+  if (!req.can('paste.edit.any') && !row.isPublic && row.uid !== req.session.uid) {
     return fail(res, '无权限查看');
   }
   row.time = Format(row.time);
@@ -55,7 +55,7 @@ exports.updatePaste = handler(async (req, res) => {
 
   const owner = await db.one('SELECT uid FROM pastes WHERE mark=?', [paste.mark]);
   if (!owner) return fail(res, '未找到');
-  if (req.session.gid < 3 && req.session.uid !== owner.uid) {
+  if (!req.can('paste.edit.any') && req.session.uid !== owner.uid) {
     return fail(res, '你只能修改自己的paste');
   }
 
@@ -71,7 +71,7 @@ exports.delPaste = handler(async (req, res) => {
   const { mark } = req.body;
   const owner = await db.one('SELECT uid FROM pastes WHERE mark=?', [mark]);
   if (!owner) return fail(res, '未找到');
-  if (req.session.gid < 3 && req.session.uid !== owner.uid) {
+  if (!req.can('paste.edit.any') && req.session.uid !== owner.uid) {
     return fail(res, '你只能删除自己的paste');
   }
   const result = await db.query('DELETE FROM pastes WHERE mark=?', [mark]);
@@ -82,7 +82,7 @@ exports.delPaste = handler(async (req, res) => {
 exports.getPasteList = handler(async (req, res) => {
   const { offset, limit } = paginate(req);
   let uid = req.body.uid || null;
-  if (req.session.gid < 3) uid = req.session.uid;
+  if (!req.can('paste.edit.any')) uid = req.session.uid;
 
   const cond = [['p.uid=?', uid]];
   const { where, params } = buildWhere(cond);

--- a/server/api/contest.js
+++ b/server/api/contest.js
@@ -1,5 +1,6 @@
 const db = require('../db');
-const { handler, fail, ok, requireRole, paginate } = require('../db/util');
+const { handler, fail, ok, paginate } = require('../db/util');
+const { requirePermission } = require('../auth/middleware');
 const { Format, briefFormat, kbFormat } = require('../static');
 const { judgeRes, formatSubmissionRow, formatCaseRow, ctype, cstatus } = require('../db/format');
 const { pushSidIntoQueue } = require('./judge');
@@ -9,6 +10,13 @@ const ctypeToIndex = { OI: 0, IOI: 1 };
 const ptype = ['传统文本比较', 'Special Judge'];
 
 // ---- shared helpers ----
+// Owner of a contest, OR holder of contest.edit.any (global or scoped to this cid).
+const canManageContest = (req, contest) => {
+  if (!contest) return false;
+  if (contest.host === req.session.uid) return true;
+  return req.can('contest.edit.any', { type: 'contest', id: Number(contest.cid) });
+};
+
 const contestStatus = (info) => {
   if (info.done) return 3;
   if (Date.now() > info.start.getTime() + info.length * 1000 * 60) return 2;
@@ -42,15 +50,17 @@ const loadContestForView = async (req, cid) => {
   const canView =
     (contest.status === 3 && (contest.isPublic || isReged)) ||
     (isReged && contest.status > 0) ||
-    req.session.gid >= 2;
+    canManageContest(req, contest);
   return { contest, status: contest.status, isReged, canView };
 };
 
+// During an OI contest in progress, regular contestants see scrubbed scores/results.
+// `manager` here means the user can manage the contest (owner / contest.edit.any).
 const formatContestSubmissionRow = async (r, ctx) => {
   r.idx = await getIdxByPid(ctx.cid, r.pid);
   r.pid = null;
   r.submitTime = Format(r.submitTime);
-  if (!ctx.contest.type && !ctx.contest.done && ctx.gid === 1) {
+  if (!ctx.contest.type && !ctx.contest.done && !ctx.manager) {
     r.score = r.judgeResult = r.time = r.memory = 0;
   }
   r.judgeResult = judgeRes[r.judgeResult];
@@ -60,7 +70,7 @@ const formatContestSubmissionRow = async (r, ctx) => {
 
 // ---- handlers ----
 exports.createContest = [
-  requireRole(2),
+  requirePermission('contest.create'),
   handler(async (req, res) => {
     const r = await db.query(
       'INSERT INTO contest(title,host,start,length,type,isPublic) VALUES (?,?,?,?,?,?)',
@@ -72,12 +82,11 @@ exports.createContest = [
 ];
 
 exports.updateContestInfo = [
-  requireRole(2),
   handler(async (req, res) => {
     const { cid, info } = req.body;
     const contest = await getContest(cid);
     if (!contest) return fail(res, '无此比赛');
-    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+    if (!canManageContest(req, contest))
       return fail(res, '你只能修改自己的比赛');
     if (contest.done) return fail(res, '比赛已经结束');
     if (!info.title || !info.start || !info.length || !info.type) return fail(res, '请确认信息完善');
@@ -122,7 +131,8 @@ exports.getContestInfo = handler(async (req, res) => {
   if (!contest) return fail(res, '无此比赛');
 
   contest.isReg = await isReg(req.session.uid, contest.cid);
-  if (!contest.isPublic && !contest.isReg && req.session.gid === 1)
+  const isManager = canManageContest(req, contest);
+  if (!contest.isPublic && !contest.isReg && !isManager)
     return fail(res, '比赛私有，请联系管理员报名');
 
   contest.playerCnt = await playerCnt(contest.cid);
@@ -131,11 +141,11 @@ exports.getContestInfo = handler(async (req, res) => {
   contest.end = Format(new Date(new Date(contest.start).getTime() + contest.length * 1000 * 60));
   contest.regAble = status < 2 && contest.isPublic && !contest.isReg;
   contest.auth = {
-    join: (contest.isReg && status > 0) || req.session.gid >= 2,
+    join: (contest.isReg && status > 0) || isManager,
     view:
       status === 3 ||
       (contest.isReg && contest.type === 1 && status > 0) ||
-      req.session.gid >= 2,
+      isManager,
   };
   contest.type = ctype[contest.type];
   contest.start = Format(contest.start);
@@ -143,34 +153,47 @@ exports.getContestInfo = handler(async (req, res) => {
   return ok(res, { data: contest });
 });
 
-exports.addPlayer = [
-  requireRole(2),
-  handler(async (req, res) => {
-    const { cid, name } = req.body;
-    const user = await db.one('SELECT uid FROM userInfo WHERE name=? LIMIT 1', [name]);
-    if (!user) return fail(res, '无此用户');
+// Owner / contest.player.manage / contest.edit.any (scoped or global) can manage players.
+const canManagePlayers = async (req, cid) => {
+  const contest = await getContest(cid);
+  if (!contest) return null;
+  const scope = { type: 'contest', id: Number(cid) };
+  if (canManageContest(req, contest)) return contest;
+  if (req.can('contest.player.manage', scope)) return contest;
+  return false;
+};
 
-    const already = await db.exists(
-      'SELECT 1 FROM contestPlayer WHERE cid=? AND uid=?',
-      [cid, user.uid]
-    );
-    if (already) return fail(res, '此用户已被添加入比赛');
+exports.addPlayer = handler(async (req, res) => {
+  const { cid, name } = req.body;
+  const allowed = await canManagePlayers(req, cid);
+  if (allowed === null) return fail(res, '无此比赛');
+  if (!allowed) return res.status(403).end('403 Forbidden');
 
-    await db.query('INSERT INTO contestPlayer(cid,uid) VALUES (?,?)', [cid, user.uid]);
-    return ok(res);
-  }),
-];
+  const user = await db.one('SELECT uid FROM userInfo WHERE name=? LIMIT 1', [name]);
+  if (!user) return fail(res, '无此用户');
 
-exports.removePlayer = [
-  requireRole(2),
-  handler(async (req, res) => {
-    const ids = (req.body.list || []).map((x) => x.id);
-    if (!ids.length) return ok(res);
-    const r = await db.query('DELETE FROM contestPlayer WHERE id in(?)', [ids]);
-    if (!r.affectedRows) return fail(res, 'error');
-    return ok(res);
-  }),
-];
+  const already = await db.exists(
+    'SELECT 1 FROM contestPlayer WHERE cid=? AND uid=?',
+    [cid, user.uid]
+  );
+  if (already) return fail(res, '此用户已被添加入比赛');
+
+  await db.query('INSERT INTO contestPlayer(cid,uid) VALUES (?,?)', [cid, user.uid]);
+  return ok(res);
+});
+
+exports.removePlayer = handler(async (req, res) => {
+  const { cid } = req.body;
+  const allowed = await canManagePlayers(req, cid);
+  if (allowed === null) return fail(res, '无此比赛');
+  if (!allowed) return res.status(403).end('403 Forbidden');
+
+  const ids = (req.body.list || []).map((x) => x.id);
+  if (!ids.length) return ok(res);
+  const r = await db.query('DELETE FROM contestPlayer WHERE id in(?) AND cid=?', [ids, cid]);
+  if (!r.affectedRows) return fail(res, 'error');
+  return ok(res);
+});
 
 exports.getPlayerList = handler(async (req, res) => {
   const { offset, limit } = paginate(req);
@@ -184,12 +207,11 @@ exports.getPlayerList = handler(async (req, res) => {
 });
 
 exports.closeContest = [
-  requireRole(2),
   handler(async (req, res) => {
     const { cid } = req.body;
     const contest = await getContest(cid);
     if (!contest) return fail(res, '无此比赛');
-    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+    if (!canManageContest(req, contest))
       return fail(res, '你只能修改自己的比赛');
     const status = contestStatus(contest);
     if (status < 2) return fail(res, '还未至比赛截止时间');
@@ -220,7 +242,7 @@ exports.getPlayerProblemList = handler(async (req, res) => {
   const reged = await isReg(req.session.uid, contest.cid);
   const status = contestStatus(contest);
   const allowed =
-    (reged && status > 0) || req.session.gid >= 2 || ((contest.isPublic || reged) && contest.done);
+    (reged && status > 0) || canManageContest(req, contest) || ((contest.isPublic || reged) && contest.done);
   if (!allowed) return res.status(403).end('403 Forbidden');
 
   const data = await db.query(
@@ -237,9 +259,10 @@ exports.getProblemInfo = handler(async (req, res) => {
   const v = await loadContestForView(req, cid);
   if (!v) return fail(res, '无此比赛');
   // 这里使用比赛进入条件，不是 view-only
+  const isManager = canManageContest(req, v.contest);
   const allowed =
     (v.isReged && v.status > 0) ||
-    req.session.gid >= 2 ||
+    isManager ||
     ((v.contest.isPublic || v.isReged) && v.contest.done);
   if (!allowed) return res.status(403).end('403 Forbidden');
 
@@ -253,7 +276,7 @@ exports.getProblemInfo = handler(async (req, res) => {
   );
   if (!problem) return fail(res, '无此题目');
 
-  if (req.session.gid >= 2) problem.pid = pinfo.pid;
+  if (isManager) problem.pid = pinfo.pid;
   problem.lang = (await getProblemLang(pinfo.pid)) & v.contest.lang;
   problem.type = ptype[problem.type];
   problem.time = briefFormat(problem.time);
@@ -263,11 +286,11 @@ exports.getProblemInfo = handler(async (req, res) => {
 });
 
 exports.getProblemList = [
-  requireRole(2),
   handler(async (req, res) => {
     const { cid } = req.body;
     const contest = await getContest(cid);
     if (!contest) return fail(res, '无此比赛');
+    if (!canManageContest(req, contest)) return res.status(403).end('403 Forbidden');
 
     const data = await db.query(
       'SELECT cp.idx,cp.pid,p.title,p.time,cp.weight,p.isPublic,p.publisher as publisherUid,u.name as publisher ' +
@@ -281,7 +304,6 @@ exports.getProblemList = [
 ];
 
 exports.updateProblemList = [
-  requireRole(2),
   handler(async (req, res) => {
     const { cid, list } = req.body;
     const seen = {};
@@ -298,7 +320,7 @@ exports.updateProblemList = [
     }
     const contest = await getContest(cid);
     if (!contest) return fail(res, '无此比赛');
-    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+    if (!canManageContest(req, contest))
       return fail(res, '你只能修改自己的比赛');
     if (contestStatus(contest) === 3) return fail(res, '比赛已结束');
 
@@ -377,7 +399,7 @@ exports.getSubmissionList = handler(async (req, res) => {
       `WHERE cid=?${extra} ORDER BY s.sid DESC LIMIT ?,?`,
     [...params, offset, limit]
   );
-  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  const ctx = { cid, contest: v.contest, manager: canManageContest(req, v.contest) };
   for (const r of list) await formatContestSubmissionRow(r, ctx);
 
   const cnt = await db.one(
@@ -403,7 +425,7 @@ exports.getLastSubmissionList = handler(async (req, res) => {
       'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.sid in (?)',
     [sids]
   );
-  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  const ctx = { cid, contest: v.contest, manager: canManageContest(req, v.contest) };
   for (const r of list) await formatContestSubmissionRow(r, ctx);
   return ok(res, { data: list, total: allLast.length });
 });
@@ -421,10 +443,12 @@ exports.getSubmissionInfo = handler(async (req, res) => {
   if (!contest) return fail(res, '无此比赛');
   contest.status = contestStatus(contest);
   const reged = await isReg(req.session.uid, row.cid);
+  const isManager = canManageContest(req, contest);
   const allowed =
     (contest.status === 3 && (contest.isPublic || reged)) ||
     req.session.uid === row.uid ||
-    req.session.gid > 1;
+    isManager ||
+    req.can('submission.view.any');
   if (!allowed) return res.status(403).end('403 Forbidden');
 
   row.caseResult = JSON.parse(row.caseResult);
@@ -432,7 +456,7 @@ exports.getSubmissionInfo = handler(async (req, res) => {
   row.singleCaseResult.sort((a, b) => a.caseId - b.caseId);
   row.done = false;
 
-  const fullView = req.session.gid > 1 || contest.status === 3;
+  const fullView = isManager || req.can('submission.view.any') || contest.status === 3;
 
   if (row.caseResult) {
     const subtaskInfo = {};
@@ -463,8 +487,8 @@ exports.getSubmissionInfo = handler(async (req, res) => {
       formatCaseRow(c);
     }
   }
-  // OI 赛制比赛中：选手只能看到提交时间，不能看到结果
-  if (!contest.type && !contest.done && req.session.gid === 1) {
+  // OI 赛制比赛中：非管理员选手只能看到提交时间，不能看到结果
+  if (!contest.type && !contest.done && !isManager) {
     row.caseResult = row.singleCaseResult = row.subtaskInfo = null;
     row.score = row.judgeResult = row.time = row.memory = 0;
     row.unShown = true;
@@ -490,7 +514,7 @@ exports.getRank = handler(async (req, res) => {
   const allowed =
     (status === 3 && (contest.isPublic || reged)) ||
     (reged && contest.type === 1 && status > 0) ||
-    req.session.gid >= 2;
+    canManageContest(req, contest);
   if (!allowed) return res.status(403).end('403 Forbidden');
 
   const pidToIdx = [];
@@ -564,7 +588,7 @@ exports.getSingleUserLastSubmission = handler(async (req, res) => {
       'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.sid in (?)',
     [sids]
   );
-  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  const ctx = { cid, contest: v.contest, manager: canManageContest(req, v.contest) };
   for (const r of list) await formatContestSubmissionRow(r, ctx);
   return ok(res, { data: list });
 });
@@ -584,11 +608,12 @@ exports.getSingleUserProblemSubmission = handler(async (req, res) => {
       'WHERE s.cid=? AND s.uid=? AND s.pid=? ORDER BY s.sid DESC',
     [cid, uid, pinfo.pid]
   );
+  const isManager = canManageContest(req, v.contest);
   for (const r of list) {
     r.idx = idx;
     r.pid = null;
     r.submitTime = Format(r.submitTime);
-    if (!v.contest.type && !v.contest.done && req.session.gid === 1) {
+    if (!v.contest.type && !v.contest.done && !isManager) {
       r.score = r.judgeResult = r.time = r.memory = 0;
     }
     r.judgeResult = judgeRes[r.judgeResult];

--- a/server/api/fileUpload.js
+++ b/server/api/fileUpload.js
@@ -8,10 +8,10 @@ const { problemAuth } = require('./problem');
 
 const CASE_MAX_TOTAL_SIZE = 200 * 1024 * 1024; // 200MB limit
 
-// Check zip file size before extraction
-const checkZipSize = (zipPath, userGid, maxTotalSize) => {
+// Check zip file size before extraction. `unlimited=true` skips the cap (super-admin equivalent).
+const checkZipSize = (zipPath, unlimited, maxTotalSize) => {
   return new Promise((resolve, reject) => {
-    if (userGid >= 3) {
+    if (unlimited) {
       resolve(true);
       return;
     }
@@ -90,11 +90,11 @@ const processUploadedFiles = async (files, destination) => {
 
 const handleCaseUpload = async (req, res) => {
   try {
-    if (req.session.gid < 2 || !((await problemAuth(req, req.body.pid)).manage)) {
+    if (!(await problemAuth(req, req.body.pid)).manage) {
       return res.status(403).end('403 Forbidden');
     }
 
-    const isSizeValid = await checkZipSize(req.file.path, req.session.gid, CASE_MAX_TOTAL_SIZE);
+    const isSizeValid = await checkZipSize(req.file.path, req.can('problem.edit.any'), CASE_MAX_TOTAL_SIZE);
     if (!isSizeValid) {
       fs.unlinkSync(req.file.path); // delete
       return res.status(202).send({

--- a/server/api/judge.js
+++ b/server/api/judge.js
@@ -3,7 +3,8 @@ const async = require('async');
 const { exec } = require('child_process');
 const { fork } = require('child_process');
 const db = require('../db');
-const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
+const { handler, fail, ok, paginate, buildWhere } = require('../db/util');
+const { requirePermission } = require('../auth/middleware');
 const { Format, kbFormat } = require('../static');
 const conf = require('../config.json');
 const { updateProblemStat, problemAuth, getProblemLang } = require('./problem');
@@ -136,10 +137,10 @@ exports.submit = handler(async (req, res) => {
 
 exports.getSubmissionList = handler(async (req, res) => {
   const { offset, limit } = paginate(req);
-  const visibility = req.session.gid < 2 ? 'p.isPublic=1' : 'p.isPublic<6';
+  const visibility = req.can('submission.view.any') ? 'p.isPublic<6' : 'p.isPublic=1';
 
-  // 只有 queryAll && gid!=1 才能跨比赛查询；否则强制 cid=0
-  const restrictToNoContest = !req.body.queryAll || req.session.gid === 1;
+  // Only callers with cross-contest visibility can pass cid via queryAll; others are forced to cid=0.
+  const restrictToNoContest = !req.body.queryAll || !req.can('contest.submission.view.cross');
   const cond = [
     restrictToNoContest ? ['s.cid=0'] : ['s.cid=?', req.body.cid],
     ['u.name=?', req.body.name],
@@ -168,7 +169,7 @@ exports.getSubmissionList = handler(async (req, res) => {
 
 exports.getSubmissionInfo = handler(async (req, res) => {
   const { sid } = req.body;
-  const visibility = req.session.gid < 2 ? ' AND p.isPublic=1' : '';
+  const visibility = req.can('submission.view.any') ? '' : ' AND p.isPublic=1';
   const row = await db.one(
     'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.code,s.codeLength,s.submitTime,s.compileResult,s.caseResult,s.machine,s.lang,u.name,p.title,p.isPublic ' +
       'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid ' +
@@ -206,7 +207,7 @@ exports.getSubmissionInfo = handler(async (req, res) => {
 });
 
 exports.reJudge = [
-  requireRole(2),
+  requirePermission('submission.rejudge'),
   handler(async (req, res) => {
     await exports.setSubmission(req.body.sid, 2, 0, 0, 0, null, null);
     pushSidIntoQueue(req.body.sid, true);
@@ -216,9 +217,11 @@ exports.reJudge = [
 ];
 
 exports.reJudgeProblem = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid } = req.body;
+    const scope = { type: 'problem', id: Number(pid) };
+    if (!req.can('submission.rejudge', scope) && !(await problemAuth(req, pid)).manage)
+      return res.status(403).end('403 Forbidden');
     const list = await db.query('SELECT sid FROM submission WHERE pid=?', [pid]);
     for (const s of list) {
       exports.setSubmission(s.sid, 2, 0, 0, 0, null, null);
@@ -231,9 +234,15 @@ exports.reJudgeProblem = [
 ];
 
 exports.reJudgeContest = [
-  requireRole(2),
   handler(async (req, res) => {
-    const list = await db.query('SELECT sid FROM submission WHERE cid=?', [req.body.cid]);
+    const cid = req.body.cid;
+    const scope = { type: 'contest', id: Number(cid) };
+    if (!req.can('submission.rejudge', scope)) {
+      const c = await db.one('SELECT host FROM contest WHERE cid=?', [cid]);
+      if (!c || (c.host !== req.session.uid && !req.can('contest.edit.any', scope)))
+        return res.status(403).end('403 Forbidden');
+    }
+    const list = await db.query('SELECT sid FROM submission WHERE cid=?', [cid]);
     for (const s of list) {
       await exports.setSubmission(s.sid, 2, 0, 0, 0, null, null);
       pushSidIntoQueue(s.sid, true);
@@ -243,7 +252,7 @@ exports.reJudgeContest = [
 ];
 
 exports.cancelSubmission = [
-  requireRole(3),
+  requirePermission('submission.rejudge'),
   handler(async (req, res) => {
     const { sid } = req.body;
     await db.query('UPDATE submission SET judgeResult=13,score=0 WHERE sid=?', [sid]);

--- a/server/api/problem.js
+++ b/server/api/problem.js
@@ -2,7 +2,8 @@ require('express-zip');
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
-const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
+const { handler, fail, ok, paginate, buildWhere } = require('../db/util');
+const { requirePermission } = require('../auth/middleware');
 const { getFile, setFile } = require('../file');
 const { briefFormat, Format, bFormat, recordEvent, kbFormat } = require('../static');
 const { judgeRes, ptype } = require('../db/format');
@@ -11,9 +12,11 @@ const { judgeRes, ptype } = require('../db/format');
 const problemAuth = async (req, pid) => {
   const row = await db.one('SELECT isPublic,publisher FROM problem WHERE pid=?', [pid]);
   if (!row) return { view: false, manage: false };
+  const scope = { type: 'problem', id: Number(pid) };
+  const isOwner = row.publisher === req.session.uid;
   return {
-    view: !!row.isPublic || req.session.gid > 1,
-    manage: row.publisher === req.session.uid || req.session.uid === 1,
+    view: !!row.isPublic || isOwner || req.can('problem.view.private'),
+    manage: isOwner || req.can('problem.edit.any', scope) || req.can('problem.case.manage', scope),
   };
 };
 exports.problemAuth = problemAuth;
@@ -37,7 +40,7 @@ exports.updateProblemStat = updateProblemStat;
 
 // ---- handlers ----
 exports.createProblem = [
-  requireRole(2),
+  requirePermission('problem.create'),
   handler(async (req, res) => {
     const r = await db.query(
       'INSERT INTO problem(title,description,publisher,time,tags) VALUES (?,?,?,?,?)',
@@ -49,7 +52,6 @@ exports.createProblem = [
 ];
 
 exports.updateProblem = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid } = req.body;
     const info = req.body.info || {};
@@ -57,7 +59,8 @@ exports.updateProblem = [
     if (!info.title || !info.description || !info.timeLimit || !info.memoryLimit || !pid)
       return fail(res, '请确认信息完善');
 
-    if (req.session.gid < 3) {
+    // Holders of global problem.edit.any (moderator+ / super_admin) bypass per-problem limits.
+    if (!req.can('problem.edit.any')) {
       if (info.timeLimit > 10000 || info.timeLimit < 0) return fail(res, '时间限制最大为10000ms');
       if (info.memoryLimit > 512 || info.memoryLimit < 0) return fail(res, '空间限制最大为512MB');
       if (info.tags?.length > 5) return fail(res, '题目标签最多设置5个');
@@ -86,7 +89,7 @@ exports.getProblemList = handler(async (req, res) => {
   const filter = req.body.filter || {};
   if (filter.level === 6) filter.level = null;
 
-  const visibility = req.session.gid > 1 ? '1=1' : 'isPublic=1';
+  const visibility = req.can('problem.view.private') ? '1=1' : 'isPublic=1';
   const tagsParam = filter.tags?.length ? JSON.stringify(filter.tags) : null;
 
   // 注意：原实现里 list 用 (title LIKE ? OR description LIKE ?)，而 count 只看 title — 这里统一用同一份条件以避免漂移
@@ -115,7 +118,7 @@ exports.getProblemList = handler(async (req, res) => {
 
 exports.getProblemInfo = handler(async (req, res) => {
   const { pid } = req.body;
-  const visibility = req.session.gid > 1 ? '' : ' AND isPublic=1';
+  const visibility = req.can('problem.view.private') ? '' : ' AND isPublic=1';
   const row = await db.one(
     'SELECT p.pid,p.title,p.acCnt,p.submitCnt,p.description,p.time,p.timeLimit,p.memoryLimit,p.isPublic,p.type,p.tags,p.level,p.lang,p.publisher as publisherUid,u.`name` as publisher ' +
       'FROM problem p INNER JOIN userInfo u ON u.uid = p.publisher WHERE pid=?' + visibility,
@@ -129,9 +132,9 @@ exports.getProblemInfo = handler(async (req, res) => {
 });
 
 exports.getProblemCasePreview = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid } = req.body;
+    if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
     const cfgRaw = await getFile(`./data/${pid}/config.json`);
     const data = cfgRaw ? JSON.parse(cfgRaw) : null;
 
@@ -178,7 +181,6 @@ exports.getProblemCasePreview = [
 ];
 
 exports.clearCase = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid } = req.body;
     if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
@@ -190,7 +192,6 @@ exports.clearCase = [
 ];
 
 exports.updateSubtaskId = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid, cases, subtask } = req.body;
     if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
@@ -248,7 +249,6 @@ exports.updateSubtaskId = [
 ];
 
 exports.getCase = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid, caseInfo } = req.body;
     if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
@@ -265,7 +265,6 @@ exports.getCase = [
 ];
 
 exports.updateCase = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid, caseInfo } = req.body;
     if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
@@ -287,13 +286,15 @@ exports.updateCase = [
 ];
 
 exports.downloadCase = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid, index } = req.query;
     const problem = await db.one('SELECT publisher FROM problem WHERE pid=?', [pid]);
     if (!problem || !fs.existsSync(`./data/${pid}/config.json`)) return fail(res, 'Not Found Error');
-    if (req.session.uid !== 1 && problem.publisher !== req.session.uid)
-      return fail(res, '你只能下载自己题目的测试点');
+    const scope = { type: 'problem', id: Number(pid) };
+    const allowed = problem.publisher === req.session.uid
+      || req.can('problem.case.manage', scope)
+      || req.can('problem.edit.any', scope);
+    if (!allowed) return fail(res, '你只能下载自己题目的测试点');
 
     const { cases } = JSON.parse(await getFile(`./data/${pid}/config.json`));
     const files = [];
@@ -361,7 +362,7 @@ exports.getProblemFastestSubmission = handler(async (req, res) => {
 exports.bindPaste2Problem = handler(async (req, res) => {
   const { pid, mark } = req.body;
   if (!pid || !mark) return fail(res, 'expect pid && mark');
-  if (req.session.gid < 2) return fail(res, '权限不足');
+  if (!(await problemAuth(req, pid)).manage) return fail(res, '权限不足');
 
   const exists = await db.exists('SELECT 1 FROM pastes WHERE mark=?', [mark]);
   if (!exists) return fail(res, `未找到mark为${mark}的剪贴板`);
@@ -386,7 +387,10 @@ exports.getProblemSol = handler(async (req, res) => {
 
 exports.unbindSol = handler(async (req, res) => {
   const { id } = req.body;
-  if (req.session.gid < 2) return fail(res, '权限不足');
+  // unbind acts on the problem the solution is bound to; require manage permission for that problem.
+  const sol = await db.one('SELECT pid FROM problemSolution WHERE id=?', [id]);
+  if (!sol) return fail(res, '记录不存在');
+  if (!(await problemAuth(req, sol.pid)).manage) return fail(res, '权限不足');
   await db.query('UPDATE problemSolution SET `show`=0 WHERE id=?', [id]);
   return ok(res);
 });

--- a/server/api/user.js
+++ b/server/api/user.js
@@ -204,7 +204,7 @@ exports.getUserPublicInfo = handler(async (req, res) => {
   if (!info) return fail(res, '无此用户');
   if (info.reg_time) info.reg_time = briefFormat(info.reg_time);
   if (info.login_time) info.login_time = briefFormat(info.login_time);
-  if (req.session.gid !== 3 && req.session.uid !== info.uid) {
+  if (!req.can('user.list') && req.session.uid !== info.uid) {
     delete info.login_time;
     delete info.email;
   }

--- a/server/app.js
+++ b/server/app.js
@@ -51,8 +51,7 @@ app.use((req, res, next) => {
   req.useragent = parser(req.headers['user-agent']);
   if (req.session.uid) {
     db.query('UPDATE userSession SET lastact=? WHERE token=? AND uid=?', [new Date(), req.sessionID, req.session.uid]).catch((err) => console.log(err));
-    if (req.url.match('^\/api\/admin') && !req.can('user.list'))
-      return res.status(403).end('403 Forbidden');
+    // Each /api/admin/* handler enforces its own fine-grained permission via requirePermission.
     next();
   } else {
     req.session.gid = 1;

--- a/server/auth/test.js
+++ b/server/auth/test.js
@@ -1,0 +1,639 @@
+// Integration tests for the RBAC permission system.
+// Runs against the real database configured in server/config.json.
+//
+//   node server/auth/test.js
+//
+// The test creates / cleans up its own sandbox users, roles and grants;
+// it does NOT touch existing data beyond reading it for verification.
+
+const path = require('path');
+process.chdir(path.join(__dirname, '..'));
+
+const db = require('../db');
+const policy = require('./policy');
+const { syncPermissionCatalog } = require('./sync');
+const { PERMISSIONS, BUILTIN_ROLES, RESOURCE_GRANTABLE } = require('./permissions');
+
+const auth = require('../api/auth');
+
+let pass = 0, fail = 0;
+const results = [];
+const ok = (name) => { pass++; results.push(['ok ', name]); };
+const ko = (name, err) => { fail++; results.push(['FAIL', `${name} -- ${err && err.message ? err.message : err}`]); };
+
+const assert = (cond, name) => { if (cond) ok(name); else ko(name, 'assertion failed'); };
+const assertEq = (a, b, name) => {
+  if (a === b) ok(name);
+  else ko(name, `expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`);
+};
+const assertSetEq = (got, want, name) => {
+  const A = new Set(got), B = new Set(want);
+  if (A.size !== B.size) return ko(name, `size ${A.size} vs ${B.size}; got=${[...A]} want=${[...B]}`);
+  for (const x of B) if (!A.has(x)) return ko(name, `missing ${x}; got=${[...A]}`);
+  ok(name);
+};
+
+const test = async (name, fn) => {
+  try { await fn(); }
+  catch (err) { ko(name, err); }
+};
+
+// ----- fake req helpers -----
+const makeReq = (uid, perms) => {
+  // recordEvent reads req.session.ip and req.useragent; provide harmless defaults
+  // so handlers don't crash inside the audit-log path during tests.
+  const session = { uid, gid: 0, ip: '127.0.0.1' };
+  return {
+    body: {},
+    session,
+    useragent: { browser: { name: 'test', version: '0' }, os: { name: 'test', version: '0' } },
+    can: (key, scope) => policy.can(perms, key, scope),
+    perms,
+  };
+};
+const fakeRes = () => {
+  const r = {
+    statusCode: 200,
+    payload: null,
+    status(s) { r.statusCode = s; return r; },
+    send(p) { r.payload = p; return r; },
+    end() { r.payload = null; return r; },
+  };
+  return r;
+};
+const runHandler = async (handler, req) => {
+  // handler can be a single fn or an array [middleware..., fn]; auth.js exports plain fns
+  // but problem.js style endpoints export arrays. We handle both for completeness.
+  const fns = Array.isArray(handler) ? handler : [handler];
+  const res = fakeRes();
+  for (const fn of fns) {
+    let nextCalled = false;
+    await new Promise((resolve) => {
+      const next = () => { nextCalled = true; resolve(); };
+      const ret = fn(req, res, next);
+      if (ret && typeof ret.then === 'function') ret.then(() => { if (!nextCalled) resolve(); });
+      else if (!nextCalled) resolve();
+    });
+    if (res.statusCode >= 400 || res.payload != null) break;
+  }
+  return res;
+};
+
+// ----- sandbox user helpers -----
+let createdUids = [];
+const mkUser = async (gid) => {
+  const r = await db.query(
+    "INSERT INTO userInfo(name,pwd,reg_time,gid,inUse) VALUES (?,?,NOW(),?,1)",
+    ['_t_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8), 'x', gid]
+  );
+  createdUids.push(r.insertId);
+  return r.insertId;
+};
+
+const cleanupSandbox = async () => {
+  if (createdUids.length) {
+    await db.query('DELETE FROM userInfo WHERE uid IN (?)', [createdUids]);
+  }
+  await db.query("DELETE FROM roles WHERE `key` LIKE 'test\\_%' ESCAPE '\\\\'");
+};
+
+// ============================================================
+//                          TESTS
+// ============================================================
+
+(async () => {
+  try {
+    // -------- 0. Schema sync --------
+    await test('syncPermissionCatalog runs without error', async () => {
+      await syncPermissionCatalog();
+    });
+
+    // -------- 1. Catalog sanity --------
+    await test('all code-defined permissions are upserted', async () => {
+      const rows = await db.query('SELECT `key` FROM permissions');
+      const dbKeys = new Set(rows.map((r) => r.key));
+      for (const k of Object.keys(PERMISSIONS)) {
+        if (!dbKeys.has(k)) throw new Error('missing permission: ' + k);
+      }
+    });
+
+    await test('all builtin roles upserted with builtin=1', async () => {
+      const rows = await db.query("SELECT `key`, builtin, legacy_gid FROM roles WHERE `key` IN (?)", [Object.keys(BUILTIN_ROLES)]);
+      const map = new Map(rows.map((r) => [r.key, r]));
+      for (const [k, meta] of Object.entries(BUILTIN_ROLES)) {
+        const row = map.get(k);
+        if (!row) throw new Error('missing role: ' + k);
+        if (row.builtin !== 1) throw new Error(`role ${k} should have builtin=1`);
+        if ((row.legacy_gid || null) !== (meta.legacy_gid || null))
+          throw new Error(`role ${k} legacy_gid mismatch: ${row.legacy_gid} vs ${meta.legacy_gid}`);
+      }
+    });
+
+    await test('moderator role has the unified permission set', async () => {
+      const rows = await db.query(
+        `SELECT p.\`key\` AS k FROM roles r
+         JOIN role_permissions rp ON rp.role_id = r.id
+         JOIN permissions p ON p.id = rp.permission_id
+         WHERE r.\`key\`=?`,
+        ['moderator']
+      );
+      const got = rows.map((r) => r.k);
+      assertSetEq(got, BUILTIN_ROLES.moderator.permissions, 'moderator permission set');
+    });
+
+    await test('super_admin role has every permission', async () => {
+      const rows = await db.query(
+        `SELECT p.\`key\` AS k FROM roles r
+         JOIN role_permissions rp ON rp.role_id = r.id
+         JOIN permissions p ON p.id = rp.permission_id
+         WHERE r.\`key\`=?`,
+        ['super_admin']
+      );
+      assertSetEq(rows.map((r) => r.k), Object.keys(PERMISSIONS), 'super_admin includes every permission key');
+    });
+
+    // -------- 2. gid -> role backfill --------
+    await test('user_roles backfilled for existing gid=3 users', async () => {
+      const users = await db.query('SELECT uid FROM userInfo WHERE gid=3 LIMIT 5');
+      if (!users.length) return ok('skip (no gid=3 users)');
+      const role = await db.one("SELECT id FROM roles WHERE `key`='super_admin'");
+      for (const u of users) {
+        const has = await db.exists('SELECT 1 FROM user_roles WHERE uid=? AND role_id=?', [u.uid, role.id]);
+        if (!has) throw new Error(`user ${u.uid} (gid=3) missing super_admin role`);
+      }
+    });
+
+    await test('user_roles backfilled for existing gid=2 users', async () => {
+      const users = await db.query('SELECT uid FROM userInfo WHERE gid=2 LIMIT 5');
+      if (!users.length) return ok('skip (no gid=2 users)');
+      const role = await db.one("SELECT id FROM roles WHERE `key`='moderator'");
+      for (const u of users) {
+        const has = await db.exists('SELECT 1 FROM user_roles WHERE uid=? AND role_id=?', [u.uid, role.id]);
+        if (!has) throw new Error(`user ${u.uid} (gid=2) missing moderator role`);
+      }
+    });
+
+    // -------- 3. policy.loadEffectivePermissions --------
+    let normalUid, modUid, superUid;
+    await test('seed sandbox users (gid=1, gid=2, gid=3)', async () => {
+      normalUid = await mkUser(1);
+      modUid = await mkUser(2);
+      superUid = await mkUser(3);
+      // run sync again to re-trigger backfill for the new users
+      await syncPermissionCatalog();
+    });
+
+    await test('normal user has zero global permissions', async () => {
+      policy.invalidate();
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assertEq(p.global.size, 0, 'global set is empty');
+      assertEq(p.denies.size, 0, 'denies set is empty');
+      assertEq(p.scoped.size, 0, 'scoped map is empty');
+    });
+
+    await test('moderator user inherits the moderator permission set', async () => {
+      policy.invalidate();
+      const p = await policy.loadEffectivePermissions(modUid);
+      assertSetEq([...p.global], BUILTIN_ROLES.moderator.permissions, 'moderator effective.global');
+    });
+
+    await test('super_admin user inherits every permission', async () => {
+      policy.invalidate();
+      const p = await policy.loadEffectivePermissions(superUid);
+      assertSetEq([...p.global], Object.keys(PERMISSIONS), 'super_admin effective.global');
+    });
+
+    // -------- 4. user_permissions: global allow + scoped + deny --------
+    await test('grant global allow → appears in effective.global', async () => {
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='contest.create'");
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id) VALUES (?,?,?,?,?)`,
+        [normalUid, perm.id, 'allow', null, null]
+      );
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(p.global.has('contest.create'), 'normal user gained contest.create globally');
+    });
+
+    await test('grant scoped allow → appears in effective.scoped, not in global', async () => {
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='problem.edit.any'");
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id) VALUES (?,?,?,?,?)`,
+        [normalUid, perm.id, 'allow', 'problem', 42]
+      );
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(!p.global.has('problem.edit.any'), 'scoped grant must NOT pollute global set');
+      assert(p.scoped.get('problem.edit.any')?.has('problem:42'), 'scoped grant lands in scoped[problem:42]');
+    });
+
+    await test('policy.can: scoped grant authorizes only the matching scope', async () => {
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(policy.can(p, 'problem.edit.any', { type: 'problem', id: 42 }), 'allowed for pid=42');
+      assert(!policy.can(p, 'problem.edit.any', { type: 'problem', id: 43 }), 'denied for pid=43');
+      assert(!policy.can(p, 'problem.edit.any'), 'no global grant');
+    });
+
+    await test('global deny overrides role-derived allow', async () => {
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='problem.delete.any'");
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id) VALUES (?,?,?,?,?)`,
+        [modUid, perm.id, 'deny', null, null]
+      );
+      policy.invalidate(modUid);
+      const p = await policy.loadEffectivePermissions(modUid);
+      assert(!policy.can(p, 'problem.delete.any'), 'moderator denied problem.delete.any after explicit deny');
+    });
+
+    // -------- 5. expires_at honored --------
+    await test('expired allow does not take effect', async () => {
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='announcement.manage'");
+      const past = new Date(Date.now() - 60_000);
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id, expires_at) VALUES (?,?,?,?,?,?)`,
+        [normalUid, perm.id, 'allow', null, null, past]
+      );
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(!p.global.has('announcement.manage'), 'expired grant filtered out');
+    });
+
+    // -------- 6. Cache + invalidate --------
+    await test('policy cache returns the same object until invalidate', async () => {
+      policy.invalidate(superUid);
+      const p1 = await policy.loadEffectivePermissions(superUid);
+      const p2 = await policy.loadEffectivePermissions(superUid);
+      assert(p1 === p2, 'cache reused across calls');
+      policy.invalidate(superUid);
+      const p3 = await policy.loadEffectivePermissions(superUid);
+      assert(p1 !== p3, 'invalidate forces a fresh load');
+    });
+
+    // -------- 7. /api/auth handlers --------
+    const superPerms = await policy.loadEffectivePermissions(superUid);
+    const normalPerms = () => policy.loadEffectivePermissions(normalUid); // re-fetch after each mutation
+
+    await test('listPermissions returns the catalog (super_admin)', async () => {
+      const req = makeReq(superUid, superPerms);
+      const res = await runHandler(auth.listPermissions, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      assert(Array.isArray(res.payload.permissions), 'permissions array');
+      assert(res.payload.permissions.length >= Object.keys(PERMISSIONS).length, 'has at least all code-defined keys');
+    });
+
+    await test('listPermissions returns 403 for normal user', async () => {
+      policy.invalidate(normalUid);
+      const req = makeReq(normalUid, await normalPerms());
+      const res = await runHandler(auth.listPermissions, req);
+      assertEq(res.statusCode, 403, 'status 403');
+    });
+
+    await test('listRoles returns roles with permission keys', async () => {
+      const req = makeReq(superUid, superPerms);
+      const res = await runHandler(auth.listRoles, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const sa = res.payload.roles.find((r) => r.key === 'super_admin');
+      assert(sa && sa.permissions.length === Object.keys(PERMISSIONS).length, 'super_admin payload includes every permission');
+    });
+
+    let customRoleId = null;
+    await test('createRole creates a custom role', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'test_custom1', name: '测试角色', description: 'desc', permissionKeys: ['problem.create'] };
+      const res = await runHandler(auth.createRole, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const row = await db.one("SELECT id, builtin FROM roles WHERE `key`=?", ['test_custom1']);
+      assert(row, 'role exists');
+      assertEq(row.builtin, 0, 'builtin=0');
+      customRoleId = row.id;
+      // permission link present
+      const link = await db.exists(
+        `SELECT 1 FROM role_permissions rp JOIN permissions p ON p.id=rp.permission_id WHERE rp.role_id=? AND p.\`key\`='problem.create'`,
+        [customRoleId]
+      );
+      assert(link, 'role_permissions row created');
+    });
+
+    await test('createRole rejects an illegal key', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'BAD-KEY', name: 'x', permissionKeys: [] };
+      const res = await runHandler(auth.createRole, req);
+      assertEq(res.statusCode, 202, 'status 202 (validation error via fail())');
+      assert(/格式/.test(res.payload.message || ''), 'rejection message about format');
+    });
+
+    await test('updateRole rejects builtin role', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'super_admin', name: 'pwn' };
+      const res = await runHandler(auth.updateRole, req);
+      assertEq(res.statusCode, 202, 'status 202');
+      assert(/内置/.test(res.payload.message || ''), 'rejection message mentions builtin');
+    });
+
+    await test('updateRole modifies a custom role and resets permissions', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'test_custom1', name: '改了名', permissionKeys: ['contest.create', 'problem.create'] };
+      const res = await runHandler(auth.updateRole, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const links = await db.query(
+        `SELECT p.\`key\` AS k FROM role_permissions rp JOIN permissions p ON p.id=rp.permission_id WHERE rp.role_id=?`,
+        [customRoleId]
+      );
+      assertSetEq(links.map((l) => l.k), ['contest.create', 'problem.create'], 'permission set replaced');
+    });
+
+    await test('setUserRoles assigns custom + builtin role to a normal user', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { uid: normalUid, roleKeys: ['test_custom1', 'problem_setter'] };
+      const res = await runHandler(auth.setUserRoles, req);
+      assertEq(res.statusCode, 200, 'status 200');
+
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      // problem.create from problem_setter; contest.create from custom role
+      assert(p.global.has('problem.create'), 'has problem.create from problem_setter');
+      assert(p.global.has('contest.create'), 'has contest.create from custom role');
+      assert(p.global.has('problem.edit.any'), 'has problem.edit.any from problem_setter');
+    });
+
+    await test('setUserRoles overwrites: removing a role drops its perms', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { uid: normalUid, roleKeys: [] };
+      const res = await runHandler(auth.setUserRoles, req);
+      assertEq(res.statusCode, 200, 'status 200');
+
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(!p.global.has('problem.create'), 'problem.create dropped');
+      // contest.create was *also* explicitly granted earlier via direct user_permissions allow,
+      // so it should still be present even after roles cleared.
+      assert(p.global.has('contest.create'), 'direct user_permissions allow survives role clear');
+    });
+
+    await test('deleteRole succeeds for unused custom role', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'test_custom1' };
+      const res = await runHandler(auth.deleteRole, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const exists = await db.exists("SELECT 1 FROM roles WHERE `key`=?", ['test_custom1']);
+      assert(!exists, 'role removed');
+    });
+
+    await test('deleteRole rejects when role still in use', async () => {
+      // Recreate, assign, try to delete.
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'test_custom2', name: 'x', permissionKeys: [] };
+      await runHandler(auth.createRole, req);
+      const req2 = makeReq(superUid, superPerms);
+      req2.body = { uid: normalUid, roleKeys: ['test_custom2'] };
+      await runHandler(auth.setUserRoles, req2);
+      const req3 = makeReq(superUid, superPerms);
+      req3.body = { key: 'test_custom2' };
+      const res = await runHandler(auth.deleteRole, req3);
+      assertEq(res.statusCode, 202, 'status 202');
+      assert(/持有/.test(res.payload.message || ''), 'message mentions still in use');
+      // cleanup: detach and delete
+      const req4 = makeReq(superUid, superPerms);
+      req4.body = { uid: normalUid, roleKeys: [] };
+      await runHandler(auth.setUserRoles, req4);
+      const req5 = makeReq(superUid, superPerms);
+      req5.body = { key: 'test_custom2' };
+      const res2 = await runHandler(auth.deleteRole, req5);
+      assertEq(res2.statusCode, 200, 'cleanup delete ok');
+    });
+
+    await test('grantUserPermission rejects scoped grant on non-scopable key', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = {
+        uid: normalUid, permissionKey: 'problem.create', effect: 'allow',
+        resourceType: 'problem', resourceId: 99,
+      };
+      const res = await runHandler(auth.grantUserPermission, req);
+      assertEq(res.statusCode, 202, 'status 202');
+      assert(/作用域/.test(res.payload.message || ''), 'rejection mentions scope');
+    });
+
+    await test('grantUserPermission upserts scoped allow then revokeUserPermission removes it', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = {
+        uid: normalUid, permissionKey: 'problem.case.manage', effect: 'allow',
+        resourceType: 'problem', resourceId: 7,
+      };
+      const res = await runHandler(auth.grantUserPermission, req);
+      assertEq(res.statusCode, 200, 'grant ok');
+
+      policy.invalidate(normalUid);
+      const p1 = await policy.loadEffectivePermissions(normalUid);
+      assert(p1.scoped.get('problem.case.manage')?.has('problem:7'), 'scoped grant active');
+
+      // upsert: re-grant with same scope, different expires
+      const req2 = makeReq(superUid, superPerms);
+      req2.body = { ...req.body, expiresAt: new Date(Date.now() + 60_000).toISOString() };
+      const res2 = await runHandler(auth.grantUserPermission, req2);
+      assertEq(res2.statusCode, 200, 'upsert ok');
+      const cnt = await db.one(
+        `SELECT COUNT(*) c FROM user_permissions up JOIN permissions p ON p.id=up.permission_id
+         WHERE up.uid=? AND p.\`key\`='problem.case.manage' AND up.resource_type='problem' AND up.resource_id=7`,
+        [normalUid]
+      );
+      assertEq(cnt.c, 1, 'exactly one row (upserted)');
+
+      // revoke
+      const row = await db.one(
+        `SELECT up.id FROM user_permissions up JOIN permissions p ON p.id=up.permission_id
+         WHERE up.uid=? AND p.\`key\`='problem.case.manage' AND up.resource_type='problem' AND up.resource_id=7`,
+        [normalUid]
+      );
+      const req3 = makeReq(superUid, superPerms);
+      req3.body = { id: row.id };
+      const res3 = await runHandler(auth.revokeUserPermission, req3);
+      assertEq(res3.statusCode, 200, 'revoke ok');
+
+      policy.invalidate(normalUid);
+      const p2 = await policy.loadEffectivePermissions(normalUid);
+      assert(!p2.scoped.get('problem.case.manage')?.has('problem:7'), 'scoped grant gone');
+    });
+
+    await test('listUserGrants returns roles + permissions for a user', async () => {
+      // give the user one role and one direct grant
+      const r1 = makeReq(superUid, superPerms);
+      r1.body = { uid: normalUid, roleKeys: ['problem_setter'] };
+      await runHandler(auth.setUserRoles, r1);
+      const r2 = makeReq(superUid, superPerms);
+      r2.body = { uid: normalUid, permissionKey: 'announcement.manage', effect: 'allow' };
+      await runHandler(auth.grantUserPermission, r2);
+
+      const r3 = makeReq(superUid, superPerms);
+      r3.body = { uid: normalUid };
+      const res = await runHandler(auth.listUserGrants, r3);
+      assertEq(res.statusCode, 200, 'status 200');
+      assert(res.payload.roles.includes('problem_setter'), 'roles list includes problem_setter');
+      const perms = res.payload.permissions.map((p) => p.permissionKey);
+      assert(perms.includes('announcement.manage'), 'permissions list includes announcement.manage');
+    });
+
+    await test('searchUsers finds the sandbox normal user by uid', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { q: String(normalUid) };
+      const res = await runHandler(auth.searchUsers, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const found = res.payload.users.find((u) => u.uid === normalUid);
+      assert(!!found, 'user appears in search results');
+    });
+
+    // -------- 8. Resource-owner authorization path --------
+    await test('resource owner can grant whitelisted permission without user.permission.grant', async () => {
+      // Insert a sandbox problem owned by normalUid.
+      const r = await db.query(
+        `INSERT INTO problem(title, description, publisher, time, tags) VALUES (?,?,?,NOW(),?)`,
+        ['_test_problem', 'desc', normalUid, '[]']
+      );
+      const pid = r.insertId;
+
+      try {
+        // normalUid has no global user.permission.grant.
+        policy.invalidate(normalUid);
+        const ownerPerms = await policy.loadEffectivePermissions(normalUid);
+        const req = makeReq(normalUid, ownerPerms);
+        req.body = {
+          uid: modUid, // give a permission to someone else
+          permissionKey: 'problem.case.manage',
+          effect: 'allow',
+          resourceType: 'problem',
+          resourceId: pid,
+        };
+        const res = await runHandler(auth.grantUserPermission, req);
+        assertEq(res.statusCode, 200, 'owner-as-grantor ok');
+
+        // verify modUid now has the scoped grant
+        policy.invalidate(modUid);
+        const mp = await policy.loadEffectivePermissions(modUid);
+        assert(mp.scoped.get('problem.case.manage')?.has(`problem:${pid}`),
+          `modUid has problem.case.manage scoped to problem:${pid}`);
+
+        // Owner cannot grant a NON-whitelisted permission via this path.
+        const req2 = makeReq(normalUid, ownerPerms);
+        req2.body = {
+          uid: modUid,
+          permissionKey: 'problem.view.private', // not in RESOURCE_GRANTABLE.problem
+          effect: 'allow',
+          resourceType: 'problem',
+          resourceId: pid,
+        };
+        const res2 = await runHandler(auth.grantUserPermission, req2);
+        // either 202 (业务错误) 或 403 — accept both. Check it didn't create a row.
+        assert(res2.statusCode !== 200, 'non-whitelisted grant rejected');
+      } finally {
+        await db.query('DELETE FROM user_permissions WHERE resource_type=? AND resource_id=?', ['problem', pid]);
+        await db.query('DELETE FROM problem WHERE pid=?', [pid]);
+      }
+    });
+
+    await test('listResourceGrants returns all grants on a resource for the owner', async () => {
+      // create a sandbox contest hosted by normalUid
+      const start = new Date();
+      const c = await db.query(
+        `INSERT INTO contest(title, host, start, length, type, isPublic) VALUES (?,?,?,?,?,?)`,
+        ['_test_contest', normalUid, start, 60, 0, 0]
+      );
+      const cid = c.insertId;
+      try {
+        // grant something to modUid scoped to this contest, via super_admin
+        const grant = makeReq(superUid, superPerms);
+        grant.body = { uid: modUid, permissionKey: 'contest.player.manage', effect: 'allow', resourceType: 'contest', resourceId: cid };
+        await runHandler(auth.grantUserPermission, grant);
+
+        policy.invalidate(normalUid);
+        const ownerPerms = await policy.loadEffectivePermissions(normalUid);
+        const req = makeReq(normalUid, ownerPerms);
+        req.body = { resourceType: 'contest', resourceId: cid };
+        const res = await runHandler(auth.listResourceGrants, req);
+        assertEq(res.statusCode, 200, 'owner can list resource grants');
+        assert(res.payload.grants.some((g) => g.uid === modUid && g.permissionKey === 'contest.player.manage'),
+          'returned grant matches');
+        assertSetEq(res.payload.grantablePermissions, RESOURCE_GRANTABLE.contest,
+          'returns whitelist for contest');
+      } finally {
+        await db.query('DELETE FROM user_permissions WHERE resource_type=? AND resource_id=?', ['contest', cid]);
+        await db.query('DELETE FROM contest WHERE cid=?', [cid]);
+      }
+    });
+
+    // -------- 9. requirePermission middleware shape --------
+    await test('requirePermission middleware blocks insufficient perms', async () => {
+      const { requirePermission } = require('./middleware');
+      const mw = requirePermission('user.role.assign');
+      policy.invalidate(normalUid);
+      const req = makeReq(normalUid, await policy.loadEffectivePermissions(normalUid));
+      const res = fakeRes();
+      let nextCalled = false;
+      await new Promise((resolve) => {
+        const r = mw(req, res, () => { nextCalled = true; resolve(); });
+        if (r && typeof r.then === 'function') r.then(() => resolve());
+      });
+      assert(!nextCalled, 'next() not called');
+      assertEq(res.statusCode, 403, 'status 403');
+    });
+
+    await test('requirePermission middleware lets super_admin through', async () => {
+      const { requirePermission } = require('./middleware');
+      const mw = requirePermission('user.role.assign');
+      const req = makeReq(superUid, superPerms);
+      const res = fakeRes();
+      let nextCalled = false;
+      await new Promise((resolve) => {
+        const r = mw(req, res, () => { nextCalled = true; resolve(); });
+        if (r && typeof r.then === 'function') r.then(() => resolve());
+      });
+      assert(nextCalled, 'next() called');
+    });
+
+    await test('requirePermission with scopeFrom honors scoped grants', async () => {
+      const { requirePermission } = require('./middleware');
+      const mw = requirePermission('problem.edit.any', {
+        scopeFrom: (req) => ({ type: 'problem', id: +req.body.pid }),
+      });
+      // Strip every role + every direct grant from normalUid so the only
+      // path to problem.edit.any is the scoped row we're about to insert.
+      await db.query('DELETE FROM user_roles WHERE uid=?', [normalUid]);
+      await db.query('DELETE FROM user_permissions WHERE uid=?', [normalUid]);
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='problem.edit.any'");
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id) VALUES (?,?,?,?,?)`,
+        [normalUid, perm.id, 'allow', 'problem', 99]
+      );
+      policy.invalidate(normalUid);
+      const req = makeReq(normalUid, await policy.loadEffectivePermissions(normalUid));
+      req.body = { pid: 99 };
+      const res = fakeRes();
+      let nextCalled = false;
+      await new Promise((resolve) => {
+        const r = mw(req, res, () => { nextCalled = true; resolve(); });
+        if (r && typeof r.then === 'function') r.then(() => resolve());
+      });
+      assert(nextCalled, 'allowed for pid=99');
+
+      // Different pid → blocked.
+      const req2 = makeReq(normalUid, await policy.loadEffectivePermissions(normalUid));
+      req2.body = { pid: 100 };
+      const res2 = fakeRes();
+      let nextCalled2 = false;
+      await new Promise((resolve) => {
+        const r = mw(req2, res2, () => { nextCalled2 = true; resolve(); });
+        if (r && typeof r.then === 'function') r.then(() => resolve());
+      });
+      assert(!nextCalled2, 'blocked for pid=100');
+      assertEq(res2.statusCode, 403, 'status 403');
+    });
+  } catch (err) {
+    console.error('FATAL:', err && err.stack ? err.stack : err);
+    fail++;
+  } finally {
+    await cleanupSandbox().catch((e) => console.error('cleanup error:', e));
+    for (const [tag, msg] of results) {
+      console.log(`  ${tag} ${msg}`);
+    }
+    console.log(`\n${pass} passed, ${fail} failed`);
+    db.pool.end(() => process.exit(fail ? 1 : 0));
+  }
+})();

--- a/web/src/components/announcement/announcementEdit.vue
+++ b/web/src/components/announcement/announcementEdit.vue
@@ -59,7 +59,7 @@ export default {
     }
   },
   mounted() {
-    if (this.$store.state.gid < 3) {
+    if (!this.$can('announcement.manage')) {
       this.$router.push('/announcement/' + this.$route.params.aid);
     }
     this.aid = this.$route.params.aid;

--- a/web/src/components/announcement/announcementView.vue
+++ b/web/src/components/announcement/announcementView.vue
@@ -6,7 +6,7 @@
           <div class="card-header">
             <p class="title">{{ announcementInfo.title }}</p>
             <p class="time">{{ announcementInfo.time }}</p>
-            <el-button v-if="this.gid === 3" type="danger" style="float: right;"
+            <el-button v-if="$can('announcement.manage')" type="danger" style="float: right;"
               @click="this.$router.push('/announcement/edit/' + announcementInfo.aid)">
               <el-icon class="el-icon--left">
                 <Edit />

--- a/web/src/components/contest/contestList.vue
+++ b/web/src/components/contest/contestList.vue
@@ -7,7 +7,7 @@
           <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
             layout="total, prev, pager, next" :total="total"></el-pagination>
           <el-button-group>
-            <el-popconfirm v-if="this.gid >= 2" confirm-button-text="确认" cancel-button-text="取消" title="确认添加比赛?"
+            <el-popconfirm v-if="$can('contest.create')" confirm-button-text="确认" cancel-button-text="取消" title="确认添加比赛?"
               @confirm="addContest">
               <template #reference>
                 <el-button type="success">

--- a/web/src/components/contest/contestMain.vue
+++ b/web/src/components/contest/contestMain.vue
@@ -68,7 +68,7 @@
               </template>
               <contestRank ref="rank" />
             </el-tab-pane>
-            <el-tab-pane name="manageC" v-if="this.gid >= 2">
+            <el-tab-pane name="manageC" v-if="canManageCollab">
               <template #label>
                 <el-icon style="margin: 4px;">
                   <SetUp />
@@ -137,7 +137,7 @@
                 </el-col>
               </el-row>
             </el-tab-pane>
-            <el-tab-pane name="manageP" v-if="this.gid >= 2">
+            <el-tab-pane name="manageP" v-if="canManageCollab">
               <template #label>
                 <el-icon style="margin: 4px;">
                   <SetUp />
@@ -145,6 +145,15 @@
                 题目管理
               </template>
               <problemManage ref="manageP" />
+            </el-tab-pane>
+            <el-tab-pane name="collaborators" v-if="canManageCollab">
+              <template #label>
+                <el-icon style="margin: 4px;">
+                  <Lock />
+                </el-icon>
+                协作者
+              </template>
+              <CollaboratorPanel resource-type="contest" :resource-id="parseInt(cid)" :visible="canManageCollab" />
             </el-tab-pane>
           </el-tabs>
         </el-card>
@@ -159,6 +168,7 @@ import contestSubmission from './components/contestSubmission.vue'
 import contestRank from './components/contestRank.vue'
 import contestProblemList from './components/contestProblemList.vue'
 import problemManage from './components/problemManage.vue'
+import CollaboratorPanel from '@/components/permission/CollaboratorPanel.vue'
 
 export default {
   name: "contestMain",
@@ -166,7 +176,14 @@ export default {
     contestSubmission,
     contestRank,
     contestProblemList,
-    problemManage
+    problemManage,
+    CollaboratorPanel,
+  },
+  computed: {
+    canManageCollab() {
+      if (this.contestInfo && this.contestInfo.host === this.$store.state.uid) return true;
+      return this.$can('contest.edit.any');
+    },
   },
   data() {
     return {

--- a/web/src/components/contest/contestPlayer.vue
+++ b/web/src/components/contest/contestPlayer.vue
@@ -7,26 +7,26 @@
           <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
             layout="total, prev, pager, next" :total="total"></el-pagination>
           <el-button-group>
-            <el-button v-if="this.gid >= 2" type="danger" @click="removePlayer" :disabled="!removeList.length">
+            <el-button v-if="$canAny('contest.edit.any','contest.player.manage')" type="danger" @click="removePlayer" :disabled="!removeList.length">
               <el-icon class="el-icon--left">
                 <Remove />
               </el-icon>
               踢出
             </el-button>
-            <el-button v-if="this.gid >= 2" type="success" :disabled="!addName.length" @click="addPlayer">
+            <el-button v-if="$canAny('contest.edit.any','contest.player.manage')" type="success" :disabled="!addName.length" @click="addPlayer">
               <el-icon class="el-icon--left">
                 <Plus />
               </el-icon>
               添加
             </el-button>
-            <el-input v-if="this.gid >= 2" v-model="addName" style="width: 150px;" placeholder="添加用户名"
+            <el-input v-if="$canAny('contest.edit.any','contest.player.manage')" v-model="addName" style="width: 150px;" placeholder="添加用户名"
               @keyup.enter="addPlayer" />
           </el-button-group>
         </div>
       </template>
       <el-table :data="playerList" height="600px" @selection-change="select" :header-cell-style="{ textAlign: 'center' }"
         :cell-style="{ textAlign: 'center' }" v-loading="!finished">
-        <el-table-column v-if="this.gid >= 2" type="selection" min-width="10%" />
+        <el-table-column v-if="$canAny('contest.edit.any','contest.player.manage')" type="selection" min-width="10%" />
         <el-table-column prop="uid" label="uid" min-width="20%" />
         <el-table-column prop="name" label="用户名" min-width="70%">
           <template #default="scope">

--- a/web/src/components/contest/contestProblem.vue
+++ b/web/src/components/contest/contestProblem.vue
@@ -73,7 +73,7 @@
             </el-icon>
             返回比赛
           </el-button>
-          <el-button v-if="this.gid >= 2" type="warning" @click="this.$router.push('/problem/' + problemInfo.pid)">
+          <el-button v-if="$can('contest.edit.any')" type="warning" @click="this.$router.push('/problem/' + problemInfo.pid)">
             <el-icon class="el-icon--left">
               <Files />
             </el-icon>

--- a/web/src/components/indexPage.vue
+++ b/web/src/components/indexPage.vue
@@ -5,7 +5,7 @@
         <template #header>
           <div class="card-header">
             公告栏
-            <el-popconfirm v-if="gid === 3" confirm-button-text="确认" cancel-button-text="取消" title="确认添加公告?"
+            <el-popconfirm v-if="$can('announcement.manage')" confirm-button-text="确认" cancel-button-text="取消" title="确认添加公告?"
               @confirm="addAnnouncement">
               <template #reference>
                 <el-button type="danger">

--- a/web/src/components/myHeader.vue
+++ b/web/src/components/myHeader.vue
@@ -56,7 +56,7 @@
         </el-icon>
         编辑资料
       </el-menu-item>
-      <el-menu-item v-if="this.$store.state.gid === 3" index="/admin/usermanage">
+      <el-menu-item v-if="$can('user.list')" index="/admin/usermanage">
         <el-icon>
           <Operation />
         </el-icon>

--- a/web/src/components/paste/pasteEdit.vue
+++ b/web/src/components/paste/pasteEdit.vue
@@ -6,10 +6,10 @@
           <div class="card-header">
             <p class="title">
               标题：<el-input v-model="paste.title" style="width: 200px; margin-right: 20px;" />
-              <el-switch :disabled="!($store.state.gid > 2 || $store.state.uid === paste.uid)" v-model="paste.isPublic" size="large" active-text="公开" inactive-text="私有" />
+              <el-switch :disabled="!($can('paste.edit.any') || $store.state.uid === paste.uid)" v-model="paste.isPublic" size="large" active-text="公开" inactive-text="私有" />
             </p>
             <el-button-group style="float: right;">
-              <el-button v-if="$store.state.gid > 2 || $store.state.uid === paste.uid" type="danger"
+              <el-button v-if="$can('paste.edit.any') || $store.state.uid === paste.uid" type="danger"
                 @click="updatePaste">更新剪贴板</el-button>
               <el-button type="primary" @click="this.$router.push('/paste/' + paste.mark)">返回剪贴板</el-button>
             </el-button-group>

--- a/web/src/components/paste/pasteView.vue
+++ b/web/src/components/paste/pasteView.vue
@@ -17,7 +17,7 @@
               </span>
             </div>
             <div style="float: right;">
-              <el-button-group v-if="this.gid === 3 || this.$store.state.uid === paste.uid" style="">
+              <el-button-group v-if="$can('paste.edit.any') || this.$store.state.uid === paste.uid" style="">
                 <el-popconfirm confirm-button-text="确认" cancel-button-text="取消" title="确认删除剪贴板?" @confirm="delPaste">
                   <template #reference>
                     <el-button type="warning">

--- a/web/src/components/permission/CollaboratorPanel.vue
+++ b/web/src/components/permission/CollaboratorPanel.vue
@@ -1,0 +1,180 @@
+<template>
+  <el-card class="box-card" shadow="hover" v-loading="loading">
+    <template #header>
+      <div class="card-header">
+        <span>协作者权限</span>
+        <el-tag size="small" type="info">{{ resourceType }} #{{ resourceId }}</el-tag>
+      </div>
+    </template>
+
+    <div v-if="!visible" style="color:#909399;">无权限管理本资源的协作者。</div>
+    <div v-else>
+      <el-table :data="grants" :cell-style="{ textAlign: 'center' }" :header-cell-style="{ textAlign: 'center' }">
+        <el-table-column label="用户" width="200">
+          <template #default="scope">
+            <router-link :to="'/user/' + scope.row.uid" class="rlink">{{ scope.row.name }} (#{{ scope.row.uid }})</router-link>
+          </template>
+        </el-table-column>
+        <el-table-column label="权限">
+          <template #default="scope">
+            <el-tag size="small">{{ permName(scope.row.permissionKey) }}</el-tag>
+            <div style="font-size:12px;color:#909399;">{{ scope.row.permissionKey }}</div>
+          </template>
+        </el-table-column>
+        <el-table-column label="过期" width="180">
+          <template #default="scope">
+            <span v-if="scope.row.expiresAt">{{ formatDate(scope.row.expiresAt) }}</span>
+            <span v-else style="color:#909399">永久</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="100">
+          <template #default="scope">
+            <el-button type="danger" size="small" plain @click="revoke(scope.row)">移除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-divider>添加协作者</el-divider>
+      <el-form :inline="true">
+        <el-form-item label="用户">
+          <UserPicker v-model="form.uid" style="width: 240px;" />
+        </el-form-item>
+        <el-form-item label="权限">
+          <PermissionPicker
+            v-model="form.permissionKey"
+            :permissions="permissions"
+            :whitelist="grantablePermissions"
+            scopable-only
+            style="width: 240px;"
+          />
+        </el-form-item>
+        <el-form-item label="过期">
+          <el-date-picker v-model="form.expiresAt" type="datetime" placeholder="（永久）" style="width: 200px;" />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" :loading="granting" @click="grant">添加</el-button>
+        </el-form-item>
+      </el-form>
+    </div>
+  </el-card>
+</template>
+
+<script>
+import axios from 'axios';
+import { ElMessageBox } from 'element-plus';
+import UserPicker from './UserPicker.vue';
+import PermissionPicker from './PermissionPicker.vue';
+
+export default {
+  name: 'CollaboratorPanel',
+  components: { UserPicker, PermissionPicker },
+  props: {
+    resourceType: { type: String, required: true },   // 'problem' | 'contest'
+    resourceId: { type: Number, required: true },
+    // visibility decided by parent (e.g. owner OR has *.edit.any). When false, panel renders an empty hint.
+    visible: { type: Boolean, default: true },
+  },
+  data() {
+    return {
+      loading: false,
+      granting: false,
+      grants: [],
+      grantablePermissions: [],
+      permissions: [],
+      form: { uid: null, permissionKey: null, expiresAt: null },
+    };
+  },
+  watch: {
+    resourceId() { this.reload(); },
+    visible(v) { if (v) this.reload(); },
+  },
+  mounted() {
+    if (this.visible) this.reload();
+  },
+  methods: {
+    permName(key) {
+      const p = this.permissions.find((x) => x.key === key);
+      return p ? p.name : key;
+    },
+    formatDate(v) {
+      if (!v) return '';
+      const d = new Date(v);
+      const pad = (n) => (n < 10 ? '0' + n : n);
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    },
+    async reload() {
+      if (!this.resourceId) return;
+      this.loading = true;
+      try {
+        const [pr, gr] = await Promise.all([
+          axios.post('/api/auth/listPermissions').catch(() => ({ data: { permissions: [] } })),
+          axios.post('/api/auth/listResourceGrants', {
+            resourceType: this.resourceType,
+            resourceId: this.resourceId,
+          }),
+        ]);
+        this.permissions = (pr.data && pr.data.permissions) || [];
+        if (gr.status === 200) {
+          this.grants = gr.data.grants || [];
+          this.grantablePermissions = gr.data.grantablePermissions || [];
+        } else if (gr.status !== 403) {
+          this.$message.error(gr.data && gr.data.message || '加载失败');
+        }
+      } catch (e) {
+        if (e.response && e.response.status === 403) {
+          // hide panel silently — parent's `visible` may have lagged behind
+          this.grants = [];
+        } else {
+          this.$message.error(e.message || '加载失败');
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+    async grant() {
+      if (!this.form.uid) { this.$message.error('请选择用户'); return; }
+      if (!this.form.permissionKey) { this.$message.error('请选择权限'); return; }
+      this.granting = true;
+      try {
+        const res = await axios.post('/api/auth/grantUserPermission', {
+          uid: this.form.uid,
+          permissionKey: this.form.permissionKey,
+          effect: 'allow',
+          resourceType: this.resourceType,
+          resourceId: this.resourceId,
+          expiresAt: this.form.expiresAt || null,
+        });
+        if (res.status === 200) {
+          this.$message.success('已添加');
+          this.form = { uid: null, permissionKey: null, expiresAt: null };
+          await this.reload();
+        } else {
+          this.$message.error(res.data && res.data.message || '添加失败');
+        }
+      } catch (e) {
+        this.$message.error(e.message || '添加失败');
+      } finally {
+        this.granting = false;
+      }
+    },
+    async revoke(row) {
+      try {
+        await ElMessageBox.confirm(`确认移除 ${row.name} 的 ${row.permissionKey} 权限？`, '提示', { type: 'warning' });
+      } catch (_) { return; }
+      try {
+        const res = await axios.post('/api/auth/revokeUserPermission', { id: row.id });
+        if (res.status === 200) { this.$message.success('已移除'); await this.reload(); }
+        else this.$message.error(res.data && res.data.message || '移除失败');
+      } catch (e) {
+        this.$message.error(e.message || '移除失败');
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.box-card { margin: 10px; }
+.card-header { display: flex; justify-content: space-between; align-items: center; }
+.rlink { color: #409eff; text-decoration: none; }
+</style>

--- a/web/src/components/problem/caseManage.vue
+++ b/web/src/components/problem/caseManage.vue
@@ -336,15 +336,14 @@ export default {
     }
   },
   mounted() {
-    if (this.$store.state.gid < 2) {
-      this.$router.push(`/problem/${this.$route.params.pid}`);
-      return;
-    }
     this.pid = this.$route.params.pid;
     axios.post('/api/problem/getProblemAuth', {
       pid: this.pid,
     }).then(res => {
       this.auth = res.data.data;
+      if (!this.auth.manage) {
+        this.$router.push(`/problem/${this.pid}`);
+      }
     });
     this.all(1);
   }

--- a/web/src/components/problem/problemEdit.vue
+++ b/web/src/components/problem/problemEdit.vue
@@ -92,14 +92,19 @@
         </div>
       </el-card>
     </el-col>
+    <el-col :span="24" v-if="auth.manage && problemInfo.pid">
+      <CollaboratorPanel resource-type="problem" :resource-id="problemInfo.pid" :visible="auth.manage" />
+    </el-col>
   </el-row>
 </template>
 
 <script>
 import axios from 'axios';
+import CollaboratorPanel from '@/components/permission/CollaboratorPanel.vue';
 
 export default {
   name: "problemEdit",
+  components: { CollaboratorPanel },
   data() {
     return {
       gid: 1,
@@ -215,15 +220,16 @@ export default {
     },
   },
   mounted() {
-    if (this.$store.state.gid < 2) {
-      this.$router.push(`/problem/${this.$route.params.pid}`);
-      return;
-    }
+    // Server-side problemAuth.manage is the final word; let the page render and rely on
+    // auth.manage to disable the save button for users who can only view.
     this.pid = this.$route.params.pid;
     axios.post('/api/problem/getProblemAuth', {
       pid: this.pid,
     }).then(res => {
       this.auth = res.data.data;
+      if (!this.auth.manage && !this.auth.view) {
+        this.$router.push(`/problem/${this.pid}`);
+      }
     });
     this.all();
   }

--- a/web/src/components/problem/problemList.vue
+++ b/web/src/components/problem/problemList.vue
@@ -7,7 +7,7 @@
           <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
             layout="total, prev, pager, next" :total="total"></el-pagination>
           <el-button-group>
-            <el-popconfirm v-if="this.gid >= 2" confirm-button-text="确认" cancel-button-text="取消" title="确认添加题目?"
+            <el-popconfirm v-if="$can('problem.create')" confirm-button-text="确认" cancel-button-text="取消" title="确认添加题目?"
               @confirm="addProblem">
               <template #reference>
                 <el-button type="success">

--- a/web/src/components/problem/problemStat.vue
+++ b/web/src/components/problem/problemStat.vue
@@ -15,7 +15,7 @@
         <template #header>
           <div class="card-header">
             题解
-            <el-button-group v-if="this.$store.state.gid > 1">
+            <el-button-group v-if="$can('problem.edit.any')">
               <el-button type="success" :disabled="!bindMark.length" @click="bindPaste2Problem">
                 <el-icon class="el-icon--left">
                   <Plus />
@@ -47,7 +47,7 @@
             </template>
           </el-table-column>
           <el-table-column prop="time" label="更新时间" min-width="20%" />
-          <el-table-column v-if="this.$store.state.gid > 1" label="操作" min-width="15%">
+          <el-table-column v-if="$can('problem.edit.any')" label="操作" min-width="15%">
             <template #default="scope">
               <el-popconfirm confirm-button-text="确认" cancel-button-text="取消" title="确认解绑?"
                 @confirm="unbindSol(scope.row.id)">

--- a/web/src/components/problem/problemView.vue
+++ b/web/src/components/problem/problemView.vue
@@ -96,7 +96,7 @@
             </el-icon>
             数据统计
           </el-button>
-          <el-button v-if="this.gid > 1" type="danger" @click="this.$router.push('/problem/edit/' + problemInfo.pid)">
+          <el-button v-if="canManage" type="danger" @click="this.$router.push('/problem/edit/' + problemInfo.pid)">
             <el-icon class="el-icon--left">
               <Operation />
             </el-icon>
@@ -114,6 +114,14 @@ import monacoEditor from '@/components/monacoEditor.vue'
 
 export default {
   name: "problemView",
+  computed: {
+    canManage() {
+      return this.problemInfo && (
+        this.problemInfo.publisherUid === this.$store.state.uid
+        || this.$can('problem.edit.any')
+      );
+    },
+  },
   data() {
     return {
       pid: 0,

--- a/web/src/components/submission/submissionList.vue
+++ b/web/src/components/submission/submissionList.vue
@@ -47,7 +47,7 @@
             <el-input v-model="filter.cid" type="text" placeholder="比赛id" style="width: 80px;" @keyup.enter="all" />
           </el-form-item>
         </el-form>
-        <span v-if="this.$store.state.gid >= 2" style="font-size: 14px; font-weight: 600; margin:0 20px 0 10px;">
+        <span v-if="$can('contest.submission.view.cross')" style="font-size: 14px; font-weight: 600; margin:0 20px 0 10px;">
           比赛提交：
           <el-switch v-model="queryAll" class="mb-2" active-text="显示" inactive-text="隐藏" @change="all" />
         </span>
@@ -194,7 +194,7 @@ export default {
       if (this.filter.score !== null) param.score = this.filter.score;
       if (this.filter.res !== null) param.res = this.filter.res;
       if (this.filter.lang !== null) param.lang = this.filter.lang;
-      if (this.queryAll && this.$store.state.gid > 1) param.queryAll = true;
+      if (this.queryAll && this.$can('contest.submission.view.cross')) param.queryAll = true;
       if (this.currentPage > 1)
         param.pageId = this.currentPage;
       let nurl = qs.stringify(param);
@@ -261,7 +261,7 @@ export default {
     if (query.pid) this.filter.pid = query.pid;
     if (query.cid) this.filter.cid = query.cid;
     if (query.lang) this.filter.lang = parseInt(query.lang);
-    if (query.queryAll && this.$store.state.gid > 1) this.queryAll = true;
+    if (query.queryAll && this.$can('contest.submission.view.cross')) this.queryAll = true;
     if (query.pageId) this.currentPage = parseInt(query.pageId);
     this.all();
   }

--- a/web/src/components/submission/submissionView.vue
+++ b/web/src/components/submission/submissionView.vue
@@ -60,7 +60,7 @@
           <div class=" card-header">
             代码
             <el-button-group>
-              <el-popconfirm v-if="gid > 2" confirm-button-text="确认" cancel-button-text="取消" title="确认取消成绩?"
+              <el-popconfirm v-if="$can('submission.rejudge')" confirm-button-text="确认" cancel-button-text="取消" title="确认取消成绩?"
                 @confirm="cancelSubmission">
                 <template #reference>
                   <el-button type="warning">
@@ -71,7 +71,7 @@
                   </el-button>
                 </template>
               </el-popconfirm>
-              <el-popconfirm v-if="gid > 1" confirm-button-text="确认" cancel-button-text="取消" title="确认重新测评?"
+              <el-popconfirm v-if="$can('submission.rejudge')" confirm-button-text="确认" cancel-button-text="取消" title="确认重新测评?"
                 @confirm="reJudge">
                 <template #reference>
                   <el-button type="danger">


### PR DESCRIPTION
> 基于 [PR 2/3 #8](https://github.com/Baymin-ty/nywOJ/pull/8)；待 PR1 → PR2 合并后我会把这条的 base 改到 main。

## Summary

完成权限系统重构的最后一步：把所有现存的 `requireRole(N)` / `req.session.gid` / `store.state.gid` 调用换成新的权限原语，并在题目/比赛编辑页内嵌「协作者」管理面板。

### 服务端（server/api/*）

- 简单 1:1 映射的中间件：`requireRole(2/3)` → `requirePermission('problem.create' / 'contest.create' / 'submission.rejudge' / 'user.list' / 'user.ban' / 'user.edit' / 'announcement.manage')`
- 「所有者或权限」型端点（`updateProblem` / `updateContestInfo` / `closeContest` / `addPlayer` / `removePlayer` / `updateProblemList` / `getCase` / `uploadData` / …）：移除 `requireRole`，handler 内通过 `problemAuth().manage` / `canManageContest()` / `canManagePlayers()` 等辅助函数完成 owner OR `req.can(key, scope)` 判定
- `problemAuth` 重写：`view` 看 `problem.view.private`；`manage` 看 owner / 范围化 `problem.edit.any` / `problem.case.manage`
- 提交可见性切换到 `submission.view.any` 与 `contest.submission.view.cross`
- paste 系列改用 `paste.edit.any`
- OI 比赛中的成绩遮蔽不再依赖 `gid===1`，改为 `!canManageContest`
- `/api/admin/*` 全局拦截已移除；每个 handler 自行用 `requirePermission` 把关

### 前端（web/src）

- 所有 `v-if` / `:disabled` / 路由跳转中对 `store.state.gid` 的判断都换成 `$can` / `$canAny`
- `problemEdit` / `caseManage` 不再用 `gid<2` 粗暴拦截；直接读取 `getProblemAuth` 的结果让服务端定夺。普通用户也能编辑自己的题目（这是设计变更，随权限系统而生）
- 顶部导航栏的「用户管理」从 `gid===3` 改为 `$can('user.list')`

### 资源协作者 UI

新增 [web/src/components/permission/CollaboratorPanel.vue](web/src/components/permission/CollaboratorPanel.vue)：

- 通用卡片：展示当前资源的 per-user grants，支持添加 / 移除
- 题目编辑页（[problemEdit.vue](web/src/components/problem/problemEdit.vue)）下方一整行；`auth.manage` 为真时显示
- 比赛主页（[contestMain.vue](web/src/components/contest/contestMain.vue)）作为新 tab，在「比赛管理」「题目管理」旁边；host 或拥有 `contest.edit.any` 时显示

### 保留项

`server/db/util.js` 中的 `requireRole` helper 保留（未删），目前已无引用；可后续 PR 清理。

## Test plan

- [ ] 普通用户给定一个 `problem_setter` 角色 → 可创建题目，但不能进入 `/admin/permissions`
- [ ] 把 `problem.edit.any` 单点 + scope=`problem:42` 授给一个普通用户 → 可编辑题目 42，对其他题目无效
- [ ] 比赛 host（普通用户）能在比赛页看到「协作者」tab，加入一个用户为协作者后该用户能编辑比赛
- [ ] 把 `paste.edit.any` 全局授给普通用户 → 能修改任意 paste；revoke 后失效
- [ ] super_admin 删自定义角色后被持有的用户失去对应权限
- [ ] `getNameColor` 仍按 `gid !== 1` 渲染管理员名字颜色（保留这个非鉴权用途）

🤖 Generated with [Claude Code](https://claude.com/claude-code)