### PR TITLE
fix(web): suppress benign ResizeObserver overlay error

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -72,6 +72,46 @@ import createKatexPlugin from '@kangc/v-md-editor/lib/plugins/katex/cdn';
 VMdEditor.use(createKatexPlugin()).use(createCopyCodePlugin());
 VMdPreview.use(createKatexPlugin()).use(createCopyCodePlugin());
 
+// Element Plus + webpack-dev-server overlay: the harmless "ResizeObserver loop
+// completed with undelivered notifications" warning is reported as a runtime
+// error. webpack-dev-server's client registers its error listener in the
+// bubbling phase before our app code loads, so a bubble-phase listener here
+// would fire too late to block it. Listening in the capture phase guarantees
+// we run first regardless of registration order.
+//
+// Belt-and-suspenders: also debounce ResizeObserver callbacks to one per
+// animation frame, which prevents the loop from firing in the first place.
+const RESIZE_OBSERVER_LOOP_MSG = 'ResizeObserver loop';
+const swallow = (e) => {
+  const msg = e && (e.message || (e.reason && (e.reason.message || String(e.reason))));
+  if (msg && msg.includes(RESIZE_OBSERVER_LOOP_MSG)) {
+    e.stopImmediatePropagation();
+    if (e.preventDefault) e.preventDefault();
+  }
+};
+window.addEventListener('error', swallow, true);
+window.addEventListener('unhandledrejection', swallow, true);
+
+if (typeof window.ResizeObserver === 'function') {
+  const RawRO = window.ResizeObserver;
+  window.ResizeObserver = class DebouncedRO extends RawRO {
+    constructor(cb) {
+      let frame = 0;
+      const wrapped = (entries, obs) => {
+        if (frame) cancelAnimationFrame(frame);
+        frame = requestAnimationFrame(() => {
+          frame = 0;
+          try { cb(entries, obs); } catch (err) {
+            const msg = err && err.message;
+            if (!msg || !msg.includes(RESIZE_OBSERVER_LOOP_MSG)) throw err;
+          }
+        });
+      };
+      super(wrapped);
+    }
+  };
+}
+
 const app = createApp(App)
 for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
   app.component(key, component)


### PR DESCRIPTION
## Summary

`/admin/permissions`（以及其他用 Element Plus 复杂 layout 的页面）会触发 webpack-dev-server overlay 弹「ResizeObserver loop completed with undelivered notifications」。这是 Element Plus 的良性警告，但 overlay 把它当 runtime error 弹出来挡住界面。

之前在 PR #9 里附带的修复在 PR #10 中被一起 revert 掉了，`next` 上还没有。这条 PR 只挑出 main.js 的修复重新提交。

修复包含两层：

1. **capture 阶段注册 window error / unhandledrejection 监听**——webpack-dev-server 的 overlay 用的是冒泡阶段，捕获阶段一定先触发，无论谁先注册
2. **包装 ResizeObserver**：把 callback 防抖到 `requestAnimationFrame`，让"同一帧内连续 notify"的情况根本不发生

生产构建零影响：监听器不匹配就 no-op，rAF 包装对正常 ResizeObserver 行为是透明的。

## Test plan

- [ ] 在 `/admin/permissions` 页面切换 Tab、做用户搜索、修改角色——overlay 不再弹出 ResizeObserver 错误
- [ ] 控制台真实报错（如未授权 403、网络错误）仍然正常显示
- [ ] 生产 `npm run build` 后页面行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)