### PR TITLE
feat(web): apply Claude Design refactor to core pages

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,19 +1,19 @@
 <template>
-  <el-container style="min-width: 992px;">
-    <el-header>
+  <el-container class="app-container">
+    <el-header class="app-header">
       <myHeader />
     </el-header>
-    <el-main>
+    <el-main class="app-main">
       <router-view :key="$route.fullPath" />
     </el-main>
-    <el-footer id="footer">
-      <div style="font-weight: 600; color:#74767a">
+    <el-footer class="app-footer">
+      <div class="footer-brand">
         nywOJ powered by
         <a href="https://github.com/Baymin-ty/nywOJ" target="_blank" class="rainbow">nywOJ</a>
         Developed by
-        <span style="color: black;">ty</span>
+        <span class="footer-author">ty</span>
       </div>
-      <div>
+      <div class="footer-icp">
         <a href="https://beian.miit.gov.cn/" target="_blank" class="rainbow">苏ICP备2025197653号-1</a>
       </div>
     </el-footer>
@@ -26,30 +26,82 @@ import axios from "axios";
 
 export default {
   name: 'App',
-  components: {
-    myHeader,
-  },
+  components: { myHeader },
   mounted() {
     axios.post('/api/judge/getLangs').then(res => {
       if (res.status === 200) {
         this.$store.state.langList = res.data.data
       }
     });
-
   },
 }
 </script>
 
 <style>
-li,
-#app {
+/* ── Reset & Base ─────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding-right: 0 !important;
+  overflow-y: overlay;
+  background: #f5f7fa;
+}
+
+#app, li {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  margin: 0 auto;
   color: #2c3e50;
 }
 
+/* ── App Layout ───────────────────────────────────────────── */
+.app-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 0;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  height: auto !important;
+}
+
+.app-main {
+  padding: 0;
+  flex: 1;
+  background: #f5f7fa;
+}
+
+.app-footer {
+  text-align: center;
+  font-family: 'Courier New', Courier, monospace;
+  background: #fff;
+  border-top: 1px solid #ebeef5;
+  padding: 16px 20px;
+  height: auto !important;
+}
+
+.footer-brand {
+  font-size: 13px;
+  font-weight: 600;
+  color: #74767a;
+  margin-bottom: 4px;
+}
+
+.footer-author {
+  color: #2c3e50;
+  font-weight: 700;
+}
+
+.footer-icp {
+  font-size: 12px;
+}
+
+/* ── Element Plus Overrides ───────────────────────────────── */
 .el-table .success {
   --el-table-tr-bg-color: var(--el-color-success-light-9);
 }
@@ -58,23 +110,23 @@ li,
   --el-table-tr-bg-color: var(--el-color-warning-light-9);
 }
 
-.el-header {
-  padding: 0;
-  position: sticky;
-  top: 0;
-  z-index: 20;
-}
-
 .el-loading-mask {
   z-index: 10;
 }
 
-body {
-  margin-top: 0;
-  padding-right: 0 !important;
-  overflow-y: overlay;
+.el-divider--horizontal {
+  margin: 10px 0;
 }
 
+.el-card__header {
+  padding: 14px 18px;
+}
+
+.el-message {
+  margin-top: 50px;
+}
+
+/* ── Global Card Header ───────────────────────────────────── */
 .card-header,
 .el-dialog__header,
 .el-form-item__label {
@@ -82,33 +134,28 @@ body {
   color: #3f3f3f;
 }
 
+/* ── Global Link ──────────────────────────────────────────── */
 .rlink {
   text-decoration: none;
   font-weight: 500;
   cursor: pointer;
   color: #558CDD;
+  transition: color 0.15s;
+}
+.rlink:hover { color: #2d71d7; }
+
+/* ── Tag text ─────────────────────────────────────────────── */
+.tag-text {
+  color: white;
+  font-weight: 600;
+  font-size: 13px;
 }
 
-.rlink:hover {
-  color: #2d71d7;
-}
-
-blockquote {
-  margin: 0;
-}
-
-#hidden {
-  margin: 5px;
-}
-
-.el-card__header {
-  padding: 15px 18px;
-}
-
+/* ── Rainbow animation ────────────────────────────────────── */
 .rainbow {
-  margin: 10px;
+  margin: 0 6px;
   text-decoration: none;
-  background-image: linear-gradient(92deg, rgb(38, 243, 93) 0%, rgb(254, 171, 58) 100%);
+  background-image: linear-gradient(92deg, rgb(38,243,93) 0%, rgb(254,171,58) 100%);
   color: rgb(38, 82, 243);
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -117,31 +164,31 @@ blockquote {
 }
 
 @keyframes hue {
-  from {
-    -webkit-filter: hue-rotate(0deg);
-  }
-
-  to {
-    -webkit-filter: hue-rotate(-360deg);
-  }
+  from { -webkit-filter: hue-rotate(0deg); }
+  to   { -webkit-filter: hue-rotate(-360deg); }
 }
 
-#footer {
-  text-align: center;
-  font-family: 'Courier New', Courier, monospace;
+/* ── Utility ──────────────────────────────────────────────── */
+#hidden { margin: 5px; }
+
+blockquote { margin: 0; }
+
+/* ── Page wrapper ─────────────────────────────────────────── */
+.page-wrap {
+  max-width: 1500px;
+  margin: 0 auto;
+  padding: 12px;
 }
 
-#footer>div {
-  margin: 5px;
-}
+.page-wrap--md  { max-width: 1300px; }
+.page-wrap--sm  { max-width: 1200px; }
+.page-wrap--sub { max-width: 1250px; }
 
+/* ── Responsive helpers ───────────────────────────────────── */
 @media (max-width: 768px) {
-  .hide-on-mobile {
-    display: none !important;
+  .hide-on-mobile { display: none !important; }
+  .page-wrap, .page-wrap--md, .page-wrap--sm, .page-wrap--sub {
+    padding: 8px;
   }
-}
-
-.el-message {
-  margin-top: 50px;
 }
 </style>

--- a/web/src/components/contest/contestList.vue
+++ b/web/src/components/contest/contestList.vue
@@ -1,160 +1,126 @@
 <template>
-  <div style="text-align: center; margin: 0 auto; max-width: 1200px">
-    <el-card class="box-card" shadow="hover">
+  <div class="page-wrap page-wrap--sm">
+    <el-card shadow="hover">
       <template #header>
-        <div class="card-header">
-          比赛列表
-          <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
-            layout="total, prev, pager, next" :total="total"></el-pagination>
-          <el-button-group>
-            <el-popconfirm v-if="this.gid >= 2" confirm-button-text="确认" cancel-button-text="取消" title="确认添加比赛?"
-              @confirm="addContest">
-              <template #reference>
-                <el-button type="success">
-                  <el-icon class="el-icon--left">
-                    <Plus />
-                  </el-icon>
-                  添加比赛
-                </el-button>
-              </template>
-            </el-popconfirm>
-            <el-button type="primary" @click="all">
-              <el-icon class="el-icon--left">
-                <Refresh />
-              </el-icon>
-              刷新
-            </el-button>
-          </el-button-group>
+        <div class="card-header card-header--wrap">
+          <span class="card-title">比赛列表</span>
+          <div class="card-header-right">
+            <el-pagination small @current-change="handleCurrentChange"
+              :current-page="currentPage" :page-size="20"
+              layout="total, prev, pager, next" :total="total" hide-on-single-page />
+            <el-button-group>
+              <el-popconfirm v-if="gid >= 2" confirm-button-text="确认" cancel-button-text="取消"
+                title="确认添加比赛?" @confirm="addContest">
+                <template #reference>
+                  <el-button type="success" size="small">
+                    <el-icon class="el-icon--left"><Plus /></el-icon>添加比赛
+                  </el-button>
+                </template>
+              </el-popconfirm>
+              <el-button type="primary" size="small" @click="all">
+                <el-icon class="el-icon--left"><Refresh /></el-icon>刷新
+              </el-button>
+            </el-button-group>
+          </div>
         </div>
       </template>
-      <el-table :data="contestList" height="600px" :header-cell-style="{ textAlign: 'center' }"
-        :cell-style="{ textAlign: 'center' }" v-loading="!finished">
-        <el-table-column prop="cid" label="#" min-width="5%" />
-        <el-table-column prop="title" label="标题" min-width="25%">
-          <template #default="scope">
-            <router-link class="rlink" :to="'/contest/' + scope.row.cid">
-              {{ scope.row.title }}
-            </router-link>
-            <el-tag style="margin-left: 10px;" size="small" :type="tagType[scope.row.status]">
-              {{ scope.row.status }}
-            </el-tag>
-          </template>
-        </el-table-column>
-        <el-table-column prop="start" label="开始时间" min-width="20%">
-          <template #default="scope">
-            <span> {{ scope.row.start }} </span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="length" label="时长" min-width="12%">
-          <template #default="scope">
-            <span> {{ scope.row.length }} min </span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="type" label="类型" min-width="7%">
-          <template #default="scope">
-            <span> {{ scope.row.type }} </span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="isPublic" label="是否公开" min-width="15%">
-          <template #default="scope">
-            <el-switch v-model="scope.row.isPublic" size="small" disabled active-text="公开" inactive-text="私有" />
-          </template>
-        </el-table-column>
-        <el-table-column prop="playerCnt" label="参赛人数" min-width="10%">
-          <template #default="scope">
-            <router-link class="rlink" :to="'/contest/player/' + scope.row.cid">
-              <el-icon id="picon" size="13">
-                <UserFilled />
-              </el-icon>
-              × {{ scope.row.playerCnt }}
-            </router-link>
-          </template>
-        </el-table-column>
-        <el-table-column prop="host" label="举办者" min-width="15%">
-          <template #default="scope">
-            <router-link class="rlink" :to="'/user/' + scope.row.host">
-              {{ scope.row.hostName }}
-            </router-link>
-          </template>
-        </el-table-column>
-      </el-table>
+
+      <div class="table-scroll">
+        <el-table
+          :data="contestList"
+          height="600px"
+          :header-cell-style="{ textAlign:'center', background:'#f5f7fa' }"
+          :cell-style="{ textAlign:'center' }"
+          v-loading="!finished"
+          style="width:100%; min-width:600px"
+        >
+          <el-table-column prop="cid" label="#" width="60" />
+          <el-table-column label="标题" min-width="220" align="left">
+            <template #default="scope">
+              <router-link class="rlink" :to="'/contest/'+scope.row.cid">{{ scope.row.title }}</router-link>
+              <el-tag style="margin-left:8px" size="small" :type="tagType[scope.row.status]">
+                {{ scope.row.status }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column label="开始时间" min-width="160" class-name="hide-on-mobile">
+            <template #default="scope">{{ scope.row.start }}</template>
+          </el-table-column>
+          <el-table-column label="时长" width="90">
+            <template #default="scope">{{ scope.row.length }} min</template>
+          </el-table-column>
+          <el-table-column prop="type" label="类型" width="70" />
+          <el-table-column label="公开" width="80" class-name="hide-on-mobile">
+            <template #default="scope">
+              <el-switch :model-value="scope.row.isPublic" size="small" disabled />
+            </template>
+          </el-table-column>
+          <el-table-column label="参赛人数" width="90">
+            <template #default="scope">
+              <router-link class="rlink" :to="'/contest/player/'+scope.row.cid">
+                × {{ scope.row.playerCnt }}
+              </router-link>
+            </template>
+          </el-table-column>
+          <el-table-column label="举办者" width="110" class-name="hide-on-mobile">
+            <template #default="scope">
+              <router-link class="rlink" :to="'/user/'+scope.row.host">{{ scope.row.hostName }}</router-link>
+            </template>
+          </el-table-column>
+        </el-table>
+      </div>
     </el-card>
   </div>
 </template>
 
 <script>
-import axios from "axios"
+import axios from "axios";
 
 export default {
   name: 'contestList',
   data() {
     return {
-      contestList: [],
-      total: 0,
-      gid: 1,
-      finished: false,
-      currentPage: 1,
-      tagType: {
-        '未开始': 'primary',
-        '正在进行': 'danger',
-        '等待测评': 'success',
-        '已结束': 'info',
-      }
-    }
+      contestList: [], total: 0, gid: 1, finished: false, currentPage: 1,
+      tagType: { '未开始': '', '正在进行': 'danger', '等待测评': 'success', '已结束': 'info' },
+    };
   },
   methods: {
     all() {
       this.finished = false;
-      axios.post('/api/contest/getContestList', {
-        pageId: this.currentPage
-      }).then(res => {
-        this.contestList = res.data.data;
-        for (let i = 0; i < this.contestList.length; i++)
-          this.contestList[i].isPublic = !!this.contestList[i].isPublic;
-        this.total = res.data.total;
-        this.finished = true;
-      }).catch(err => {
-        this.$message.error('获取比赛列表失败' + err.message);
-      });
+      axios.post('/api/contest/getContestList', { pageId: this.currentPage })
+        .then(res => {
+          this.contestList = res.data.data.map(c => ({ ...c, isPublic: !!c.isPublic }));
+          this.total = res.data.total;
+          this.finished = true;
+        }).catch(err => { this.$message.error('获取比赛列表失败 ' + err.message); });
     },
-    handleCurrentChange(val) {
-      this.currentPage = val;
-      this.all();
-    },
+    handleCurrentChange(val) { this.currentPage = val; this.all(); },
     addContest() {
       axios.post('/api/contest/createContest').then(res => {
-        if (res.status === 200) {
-          this.$router.push({
-            path: '/contest/' + res.data.cid,
-            query: { tab: 'manageC' }
-          });
-        } else {
-          this.$message.error('添加比赛失败' + res.data.message);
-        }
+        if (res.status === 200)
+          this.$router.push({ path: '/contest/' + res.data.cid, query: { tab: 'manageC' } });
+        else this.$message.error('添加比赛失败 ' + res.data.message);
       });
     },
   },
-  async mounted() {
+  mounted() {
     this.gid = this.$store.state.gid;
     this.all();
-  }
-}
+  },
+};
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.box-card {
-  margin: 10px;
-}
-
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 20px;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-weight: bolder;
+  color: #3f3f3f;
 }
-
-#picon {
-  vertical-align: -2px;
-}
+.card-title { font-size: 15px; }
+.card-header-right { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.table-scroll { overflow-x: auto; }
 </style>

--- a/web/src/components/indexPage.vue
+++ b/web/src/components/indexPage.vue
@@ -1,122 +1,239 @@
 <template>
-  <el-row style="margin: auto;max-width: 1500px;">
-    <el-col :xs="24" :sm="24" :md="16">
-      <el-card class="box-card" shadow="hover">
-        <template #header>
-          <div class="card-header">
-            公告栏
-            <el-popconfirm v-if="gid === 3" confirm-button-text="确认" cancel-button-text="取消" title="确认添加公告?"
-              @confirm="addAnnouncement">
-              <template #reference>
-                <el-button type="danger">
-                  <el-icon class="el-icon--left">
-                    <Plus />
-                  </el-icon>
-                  添加公告
-                </el-button>
+  <div class="page-wrap">
+    <el-row :gutter="12">
+      <!-- Left column -->
+      <el-col :xs="24" :md="16">
+        <!-- Announcements -->
+        <el-card shadow="hover" class="mb-12">
+          <template #header>
+            <div class="card-header">
+              <span>公告栏</span>
+              <el-button v-if="gid === 3" type="danger" size="small" @click="addAnnouncement">
+                <el-icon class="el-icon--left"><Plus /></el-icon>添加公告
+              </el-button>
+            </div>
+          </template>
+          <el-table :data="announcements" v-loading="!announcements.length" style="width:100%">
+            <el-table-column prop="title" label="标题" min-width="65%">
+              <template #default="scope">
+                <router-link :to="'/announcement/' + scope.row.aid" class="rlink">{{ scope.row.title }}</router-link>
               </template>
-            </el-popconfirm>
-          </div>
-        </template>
-        <el-table :data="announcements" v-loading="!announcements.length">
-          <el-table-column prop="title" label="标题" min-width="60%">
-            <template #default="scope">
-              <router-link :to="'/announcement/' + scope.row.aid" class="rlink">
-                {{ scope.row.title }}
-              </router-link>
-            </template>
-          </el-table-column>
-          <el-table-column prop="time" label="发布时间" min-width="40%" />
-        </el-table>
-      </el-card>
-      <cuteRank />
-    </el-col>
-    <el-col :xs="24" :sm="24" :md="8">
-      <el-card class="box-card" shadow="hover">
-        <template #header>
-          <div class="card-header">
-            一言（ヒトコト）
-            <el-button type="primary" @click="updateHitokoto" color="#626aef" plain>
-              <el-icon class="el-icon--left">
-                <Refresh />
-              </el-icon>
-              再来一个
-            </el-button>
-          </div>
-        </template>
-        <div style="font-size: 14px; "> {{ motto.hitokoto }} </div>
-        <div style="font-size: 12px; color: grey; float: right;margin: 10px;"> from {{ motto.from }} </div>
-      </el-card>
-      <rabbitData />
-    </el-col>
-  </el-row>
+            </el-table-column>
+            <el-table-column prop="time" label="发布时间" min-width="35%" align="center" />
+          </el-table>
+        </el-card>
+
+        <!-- Rabbit rank -->
+        <el-card shadow="hover">
+          <template #header>
+            <div class="card-header">
+              <span>点击数排名</span>
+              <el-pagination
+                small
+                layout="prev, pager, next"
+                :total="rankTotal"
+                :page-size="10"
+                :current-page="rankPage"
+                @current-change="handleRankPage"
+              />
+            </div>
+          </template>
+          <el-table :data="rankList" v-loading="!rankLoaded" style="width:100%"
+            :row-class-name="rankRowClass">
+            <el-table-column prop="rank" label="#" width="50" align="center" />
+            <el-table-column label="用户名" min-width="25%" align="center">
+              <template #default="scope">
+                <div class="rank-user">
+                  <el-avatar :size="26" :src="scope.row.avatar || '/default-avatar.svg'" />
+                  <router-link :to="'/user/' + scope.row.uid" class="rlink"
+                    :style="{ color: getNameColor(scope.row.gid, scope.row.clickCnt),
+                               fontWeight: scope.row.gid !== 1 ? 900 : 500 }">
+                    {{ scope.row.name }}
+                  </router-link>
+                </div>
+              </template>
+            </el-table-column>
+            <el-table-column prop="clickCnt" label="点击次数" min-width="20%" align="center" />
+            <el-table-column label="个人主页" min-width="35%" class-name="hide-on-mobile">
+              <template #default="scope">
+                <span class="motto-cell">{{ scope.row.motto || '—' }}</span>
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-card>
+      </el-col>
+
+      <!-- Right column -->
+      <el-col :xs="24" :md="8">
+        <!-- Hitokoto -->
+        <el-card shadow="hover" class="mb-12">
+          <template #header>
+            <div class="card-header">
+              <span>一言（ヒトコト）</span>
+              <el-button type="primary" size="small" @click="updateHitokoto" color="#626aef" plain>
+                <el-icon class="el-icon--left"><Refresh /></el-icon>再来一个
+              </el-button>
+            </div>
+          </template>
+          <p class="hitokoto-text">{{ motto.hitokoto }}</p>
+          <p class="hitokoto-from">from {{ motto.from }}</p>
+        </el-card>
+
+        <!-- Rabbit click stats -->
+        <el-card shadow="hover">
+          <template #header><div class="card-header"><span>点击数统计</span></div></template>
+          <div ref="chartContainer" class="chart-container"></div>
+        </el-card>
+      </el-col>
+    </el-row>
+  </div>
 </template>
 
 <script>
 import axios from "axios";
-import cuteRank from '@/components/rabbit/cuteRankList.vue'
-import rabbitData from '@/components/rabbit/rabbitClickData.vue'
+import { getNameColor } from '@/assets/common';
+import * as echarts from 'echarts/core';
+import { LineChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+echarts.use([LineChart, GridComponent, TooltipComponent, CanvasRenderer]);
 
 export default {
-  name: "myHeader",
-  components: {
-    rabbitData,
-    cuteRank,
-  },
+  name: "indexPage",
   data() {
     return {
-      motto: {},
+      motto: { hitokoto: '…', from: '/' },
       announcements: [],
       gid: 0,
-    }
+      rankList: [],
+      rankLoaded: false,
+      rankTotal: 0,
+      rankPage: 1,
+      myUid: 0,
+    };
   },
   methods: {
+    getNameColor,
+    rankRowClass({ row }) {
+      return row.uid === this.myUid ? 'success' : '';
+    },
     updateHitokoto() {
       axios.post('/api/common/getHitokoto').then(res => {
-        if (res.status === 200)
-          this.motto = res.data
-        else {
-          this.motto.hitokoto = "加载一言时发生错误。";
-          this.motto.from = "/";
-        }
-      }).catch(() => {
-        this.motto.hitokoto = "加载一言时发生错误。";
-        this.motto.from = "/";
-      });
+        this.motto = res.status === 200 ? res.data : { hitokoto: '加载失败', from: '/' };
+      }).catch(() => { this.motto = { hitokoto: '加载失败', from: '/' }; });
     },
     getAnnouncements() {
       axios.post('/api/common/getAnnouncementList').then(res => {
         this.announcements = res.data.data;
       });
     },
+    getRankList() {
+      this.rankLoaded = false;
+      axios.post('/api/rabbit/getRankInfo', { pageId: this.rankPage }).then(res => {
+        this.rankList = res.data.data || [];
+        this.rankTotal = res.data.total || 0;
+        this.rankLoaded = true;
+      }).catch(() => { this.rankLoaded = true; });
+    },
+    handleRankPage(page) {
+      this.rankPage = page;
+      this.getRankList();
+    },
     addAnnouncement() {
       axios.post('/api/admin/addAnnouncement').then(res => {
-        if (res.status === 200)
-          this.$router.push('/announcement/edit/' + res.data.aid);
-        else
-          this.$message.error('添加公告失败' + res.data.message);
+        if (res.status === 200) this.$router.push('/announcement/edit/' + res.data.aid);
+        else this.$message.error('添加公告失败 ' + res.data.message);
       });
-    }
+    },
+    initChart() {
+      axios.post('/api/rabbit/getClickData', { day: 7 }).then(res => {
+        const data = res.data?.data || [];
+        const dates       = data.map(d => d.date);
+        const totalClicks = data.map(d => d.clickCnt);
+        const userClicks  = data.map(d => d.userCnt);
+
+        const chart = echarts.init(this.$refs.chartContainer);
+        chart.setOption({
+          tooltip: { trigger: 'axis' },
+          grid: [
+            { top: 20, bottom: '55%', left: 40, right: 10 },
+            { top: '55%', bottom: 30, left: 40, right: 10 },
+          ],
+          xAxis: [
+            { type: 'category', data: dates, gridIndex: 0, axisLabel: { fontSize: 10 } },
+            { type: 'category', data: dates, gridIndex: 1, axisLabel: { fontSize: 10 } },
+          ],
+          yAxis: [
+            { type: 'value', gridIndex: 0, axisLabel: { fontSize: 10 }, minInterval: 1 },
+            { type: 'value', gridIndex: 1, axisLabel: { fontSize: 10 }, minInterval: 1 },
+          ],
+          series: [
+            { name: '每日点击总次数', type: 'line', data: totalClicks, xAxisIndex: 0, yAxisIndex: 0, smooth: true, color: '#409EFF', areaStyle: { opacity: 0.1 } },
+            { name: '每日点击用户数', type: 'line', data: userClicks,  xAxisIndex: 1, yAxisIndex: 1, smooth: true, color: '#67c23a', areaStyle: { opacity: 0.1 } },
+          ],
+        });
+        window.addEventListener('resize', () => chart.resize());
+      }).catch(() => {});
+    },
   },
   mounted() {
-    this.gid = this.$store.state.gid;
+    this.gid    = this.$store.state.gid;
+    this.myUid  = this.$store.state.uid;
     this.updateHitokoto();
     this.getAnnouncements();
+    this.getRankList();
+    this.$nextTick(this.initChart);
   },
-}
+};
 </script>
 
 <style scoped>
-.box-card {
-  margin: 10px;
-  text-align: center;
-}
+.mb-12 { margin-bottom: 12px; }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 20px;
   font-weight: bolder;
+  color: #3f3f3f;
+}
+
+.hitokoto-text {
+  font-size: 14px;
+  line-height: 1.7;
+  color: #2c3e50;
+  margin: 0 0 12px;
+}
+.hitokoto-from {
+  font-size: 12px;
+  color: #909399;
+  text-align: right;
+  margin: 0;
+}
+
+.rank-user {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.motto-cell {
+  font-size: 12px;
+  color: #909399;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.chart-container {
+  width: 100%;
+  height: 260px;
+}
+
+@media (max-width: 768px) {
+  .mb-12 { margin-bottom: 8px; }
+  .chart-container { height: 200px; }
 }
 </style>

--- a/web/src/components/myHeader.vue
+++ b/web/src/components/myHeader.vue
@@ -1,83 +1,124 @@
 <template>
-  <el-menu mode="horizontal" :default-active="this.$store.state.activeTitle" :router="true">
-    <el-menu-item index="/rabbit" style="height: auto">
-      <img style="margin-top: 3px;" src="../assets/icon.png" class="icon">
-    </el-menu-item>
-    <el-menu-item index="/">
-      <el-icon>
-        <Lollipop />
-      </el-icon>
-      首页
-    </el-menu-item>
-    <el-menu-item index="/problem">
-      <el-icon>
-        <Files />
-      </el-icon>
-      题库
-    </el-menu-item>
-    <el-menu-item index="/contest">
-      <el-icon>
-        <Trophy />
-      </el-icon>
-      比赛
-    </el-menu-item>
-    <el-menu-item index="/submission">
-      <el-icon>
-        <DataAnalysis />
-      </el-icon>
-      提交记录
-    </el-menu-item>
-    <el-menu-item v-if="!this.$store.state.uid" index="/user/login">
-      <el-icon>
-        <User />
-      </el-icon>
-      登录
-    </el-menu-item>
-    <el-menu-item v-if="!this.$store.state.uid" index="/user/reg">
-      <el-icon>
-        <CircleCheck />
-      </el-icon>
-      注册
-    </el-menu-item>
-    <el-sub-menu index="/user" v-if="this.$store.state.uid">
-      <template #title>
-        <el-avatar :size="35" :src="this.$store.state.avatar" />
-        <span style="padding-left: 8px;"> {{ this.$store.state.name }} </span>
+  <div class="header-root">
+    <!-- Desktop nav -->
+    <nav class="nav-desktop">
+      <!-- Logo -->
+      <router-link to="/rabbit" class="nav-logo">
+        <img src="../assets/icon.png" class="nav-icon" alt="nywOJ" />
+      </router-link>
+
+      <!-- Nav items -->
+      <router-link
+        v-for="item in navItems"
+        :key="item.path"
+        :to="item.path"
+        class="nav-item"
+        :class="{ 'nav-item--active': isActive(item.path) }"
+      >
+        <el-icon><component :is="item.icon" /></el-icon>
+        <span>{{ item.label }}</span>
+      </router-link>
+
+      <div class="nav-spacer"></div>
+
+      <!-- Guest -->
+      <template v-if="!$store.state.uid">
+        <router-link to="/user/login" class="nav-item">
+          <el-icon><User /></el-icon><span>登录</span>
+        </router-link>
+        <router-link to="/user/reg" class="nav-item nav-item--reg">
+          <el-icon><CircleCheck /></el-icon><span>注册</span>
+        </router-link>
       </template>
-      <el-menu-item :index="/user/ + this.$store.state.uid">
-        <el-icon>
-          <UserFilled />
-        </el-icon>
-        个人主页
-      </el-menu-item>
-      <el-menu-item index="/user/edit">
-        <el-icon>
-          <Edit />
-        </el-icon>
-        编辑资料
-      </el-menu-item>
-      <el-menu-item v-if="this.$store.state.gid === 3" index="/admin/usermanage">
-        <el-icon>
-          <Operation />
-        </el-icon>
-        用户管理
-      </el-menu-item>
-      <el-menu-item index="/paste">
-        <el-icon>
-          <Document />
-        </el-icon>
-        剪贴板板
-      </el-menu-item>
-      <span @click="logout">
-        <el-menu-item>
-          <el-icon>
-            <Close />
-          </el-icon>
-          退出登录
-        </el-menu-item>
-      </span>
-    </el-sub-menu>
-  </el-menu>
+
+      <!-- Logged in -->
+      <el-dropdown v-else trigger="click" @command="handleCommand">
+        <div class="nav-user">
+          <el-avatar :size="32" :src="$store.state.avatar" />
+          <span class="nav-username">{{ $store.state.name }}</span>
+          <el-icon class="nav-caret"><ArrowDown /></el-icon>
+        </div>
+        <template #dropdown>
+          <el-dropdown-menu>
+            <el-dropdown-item command="profile">
+              <el-icon><UserFilled /></el-icon> 个人主页
+            </el-dropdown-item>
+            <el-dropdown-item command="edit">
+              <el-icon><Edit /></el-icon> 编辑资料
+            </el-dropdown-item>
+            <el-dropdown-item v-if="$store.state.gid === 3" command="admin">
+              <el-icon><Operation /></el-icon> 用户管理
+            </el-dropdown-item>
+            <el-dropdown-item command="paste">
+              <el-icon><Document /></el-icon> 剪贴板
+            </el-dropdown-item>
+            <el-dropdown-item divided command="logout">
+              <el-icon><SwitchButton /></el-icon> 退出登录
+            </el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
+    </nav>
+
+    <!-- Mobile nav -->
+    <nav class="nav-mobile">
+      <router-link to="/rabbit" class="nav-logo">
+        <img src="../assets/icon.png" class="nav-icon" alt="nywOJ" />
+      </router-link>
+      <span class="nav-mobile-title">nywOJ</span>
+      <div class="nav-spacer"></div>
+      <button class="hamburger" @click="mobileOpen = !mobileOpen" :aria-expanded="mobileOpen">
+        <span></span><span></span><span></span>
+      </button>
+    </nav>
+
+    <!-- Mobile drawer -->
+    <transition name="drawer">
+      <div v-if="mobileOpen" class="mobile-drawer">
+        <router-link
+          v-for="item in navItems"
+          :key="item.path"
+          :to="item.path"
+          class="drawer-item"
+          @click="mobileOpen = false"
+        >
+          <el-icon><component :is="item.icon" /></el-icon>
+          <span>{{ item.label }}</span>
+        </router-link>
+        <div class="drawer-divider"></div>
+        <template v-if="!$store.state.uid">
+          <router-link to="/user/login" class="drawer-item" @click="mobileOpen = false">
+            <el-icon><User /></el-icon><span>登录</span>
+          </router-link>
+          <router-link to="/user/reg" class="drawer-item" @click="mobileOpen = false">
+            <el-icon><CircleCheck /></el-icon><span>注册</span>
+          </router-link>
+        </template>
+        <template v-else>
+          <div class="drawer-user">
+            <el-avatar :size="36" :src="$store.state.avatar" />
+            <span>{{ $store.state.name }}</span>
+          </div>
+          <router-link :to="'/user/' + $store.state.uid" class="drawer-item" @click="mobileOpen = false">
+            <el-icon><UserFilled /></el-icon><span>个人主页</span>
+          </router-link>
+          <router-link to="/user/edit" class="drawer-item" @click="mobileOpen = false">
+            <el-icon><Edit /></el-icon><span>编辑资料</span>
+          </router-link>
+          <router-link v-if="$store.state.gid === 3" to="/admin/usermanage" class="drawer-item" @click="mobileOpen = false">
+            <el-icon><Operation /></el-icon><span>用户管理</span>
+          </router-link>
+          <router-link to="/paste" class="drawer-item" @click="mobileOpen = false">
+            <el-icon><Document /></el-icon><span>剪贴板</span>
+          </router-link>
+          <div class="drawer-item drawer-item--danger" @click="logout">
+            <el-icon><SwitchButton /></el-icon><span>退出登录</span>
+          </div>
+        </template>
+      </div>
+    </transition>
+    <div v-if="mobileOpen" class="drawer-mask" @click="mobileOpen = false"></div>
+  </div>
 </template>
 
 <script>
@@ -87,58 +128,202 @@ export default {
   name: "myHeader",
   data() {
     return {
-      uid: 0,
-      name: "/",
-      gid: 1,
-      money: 50,
-      curPath: '',
-      options: [{
-        value: 50,
-        label: '一包辣条',
-      }, {
-        value: 100,
-        label: '一根冰棍',
-      }, {
-        value: 300,
-        label: '一瓶可乐',
-      }],
-    }
+      mobileOpen: false,
+      navItems: [
+        { path: '/',           label: '首页',   icon: 'Lollipop'     },
+        { path: '/problem',    label: '题库',   icon: 'Files'        },
+        { path: '/contest',    label: '比赛',   icon: 'Trophy'       },
+        { path: '/submission', label: '提交记录', icon: 'DataAnalysis' },
+      ],
+    };
   },
   methods: {
+    isActive(path) {
+      if (path === '/') return this.$route.path === '/';
+      return this.$route.path.startsWith(path);
+    },
+    handleCommand(cmd) {
+      const map = {
+        profile: '/user/' + this.$store.state.uid,
+        edit:    '/user/edit',
+        admin:   '/admin/usermanage',
+        paste:   '/paste',
+        logout:  null,
+      };
+      if (cmd === 'logout') { this.logout(); return; }
+      this.$router.push(map[cmd]);
+    },
     logout() {
       axios.post('/api/user/logout').then(() => {
         this.$store.state.uid = 0;
         this.$store.state.name = '/';
         this.$store.state.gid = 0;
+        this.mobileOpen = false;
         this.$router.push('/');
       });
-    }
-  }
+    },
+  },
 }
 </script>
 
-<style>
-.icon {
-  border-radius: 5px;
-  width: 40px;
-  height: 40px;
+<style scoped>
+/* ── Shared ──────────────────────────────────────────────── */
+.header-root {
+  background: #fff;
+  border-bottom: 1px solid #e4e7ed;
+  position: relative;
 }
 
-.pd .el-dialog__body {
-  padding: 0;
-}
+.nav-logo { display: flex; align-items: center; padding: 0 10px; height: 100%; }
+.nav-icon  { width: 38px; height: 38px; border-radius: 6px; display: block; }
+.nav-spacer { flex: 1; }
 
-.el-divider--horizontal {
-  margin: 10px 0;
-}
-
-.el-menu--collapse .el-menu .el-submenu,
-.el-menu--popup {
-  min-width: 100px !important;
-  font-size: 10px;
-}
-
-.el-menu {
+/* ── Desktop ─────────────────────────────────────────────── */
+.nav-desktop {
+  display: flex;
+  align-items: center;
   justify-content: center;
+  height: 60px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 8px;
+}
+
+.nav-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 16px;
+  height: 60px;
+  font-size: 14px;
+  color: #303133;
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: color 0.2s, border-color 0.2s;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.nav-item:hover { color: #409EFF; }
+.nav-item--active { color: #409EFF; border-bottom-color: #409EFF; }
+
+.nav-item--reg {
+  margin-left: 4px;
+  border: 1px solid #409EFF;
+  border-radius: 20px;
+  height: 34px;
+  padding: 0 14px;
+  color: #409EFF;
+  font-size: 13px;
+}
+.nav-item--reg:hover { background: #ecf5ff; }
+
+.nav-user {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  height: 60px;
+  cursor: pointer;
+  color: #303133;
+  font-size: 14px;
+}
+.nav-user:hover { color: #409EFF; }
+.nav-username { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nav-caret { font-size: 12px; color: #909399; }
+
+/* ── Mobile ──────────────────────────────────────────────── */
+.nav-mobile {
+  display: none;
+  align-items: center;
+  height: 54px;
+  padding: 0 12px;
+}
+.nav-mobile-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #2c3e50;
+  margin-left: 4px;
+}
+
+.hamburger {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 24px;
+  height: 18px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+.hamburger span {
+  display: block;
+  height: 2px;
+  background: #303133;
+  border-radius: 2px;
+  transition: all 0.2s;
+}
+
+/* ── Drawer ──────────────────────────────────────────────── */
+.mobile-drawer {
+  position: fixed;
+  top: 54px;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border-top: 1px solid #ebeef5;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+  z-index: 999;
+  padding: 8px 0 16px;
+}
+
+.drawer-mask {
+  position: fixed;
+  inset: 0;
+  top: 54px;
+  background: rgba(0,0,0,0.2);
+  z-index: 998;
+}
+
+.drawer-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  font-size: 15px;
+  color: #303133;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.drawer-item:hover { background: #f5f7fa; }
+.drawer-item--danger { color: #f56c6c; }
+
+.drawer-user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #2c3e50;
+  background: #f5f7fa;
+  margin-bottom: 4px;
+}
+
+.drawer-divider {
+  height: 1px;
+  background: #f0f0f0;
+  margin: 6px 0;
+}
+
+/* ── Drawer transition ───────────────────────────────────── */
+.drawer-enter-active, .drawer-leave-active { transition: opacity 0.18s, transform 0.18s; }
+.drawer-enter-from, .drawer-leave-to { opacity: 0; transform: translateY(-8px); }
+
+/* ── Breakpoint ──────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .nav-desktop { display: none; }
+  .nav-mobile  { display: flex; }
 }
 </style>

--- a/web/src/components/problem/problemList.vue
+++ b/web/src/components/problem/problemList.vue
@@ -1,202 +1,142 @@
 <template>
-  <div style="text-align: center; margin: 0 auto; max-width: 1300px">
-    <el-card class="box-card" shadow="hover">
+  <div class="page-wrap page-wrap--md">
+    <el-card shadow="hover">
       <template #header>
-        <div class="card-header">
-          题目列表
-          <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
-            layout="total, prev, pager, next" :total="total"></el-pagination>
-          <el-button-group>
-            <el-popconfirm v-if="this.gid >= 2" confirm-button-text="确认" cancel-button-text="取消" title="确认添加题目?"
-              @confirm="addProblem">
-              <template #reference>
-                <el-button type="success">
-                  <el-icon class="el-icon--left">
-                    <Plus />
-                  </el-icon>
-                  添加题目
-                </el-button>
-              </template>
-            </el-popconfirm>
-            <el-button type="primary" @click="all">
-              <el-icon class="el-icon--left">
-                <Refresh />
-              </el-icon>
-              刷新
-            </el-button>
-          </el-button-group>
+        <div class="card-header card-header--wrap">
+          <span class="card-title">题目列表</span>
+          <div class="card-header-right">
+            <el-pagination
+              small
+              @current-change="handleCurrentChange"
+              :current-page="currentPage"
+              :page-size="20"
+              layout="total, prev, pager, next"
+              :total="total"
+              hide-on-single-page
+            />
+            <el-button-group>
+              <el-popconfirm v-if="gid >= 2" confirm-button-text="确认" cancel-button-text="取消"
+                title="确认添加题目?" @confirm="addProblem">
+                <template #reference>
+                  <el-button type="success" size="small">
+                    <el-icon class="el-icon--left"><Plus /></el-icon>添加题目
+                  </el-button>
+                </template>
+              </el-popconfirm>
+              <el-button type="primary" size="small" @click="all">
+                <el-icon class="el-icon--left"><Refresh /></el-icon>刷新
+              </el-button>
+            </el-button-group>
+          </div>
         </div>
       </template>
-      <div style="display: inline-flex;">
-        <el-form :inline="true" :model="filter">
-          <el-form-item>
-            <el-input v-model="pid" type="text" placeholder="pid跳转" style="width: 70px;"
-              @keyup.enter="this.$router.push('/problem/' + pid)" />
-          </el-form-item>
-          <el-form-item>
-            <el-input v-model="filter.name" type="text" placeholder="题目标题或内容" style="width: 140px;" @keyup.enter="all" />
-          </el-form-item>
-          <el-form-item>
-            <el-select v-model="filter.publisherUid" filterable clearable placeholder="出题人" style="width: 160px;"
-              @change="all">
-              <el-option v-for="p in publisherList" :key="p.publisher" :label="p.name" :value="p.publisher" />
-            </el-select>
-          </el-form-item>
-          <el-form-item>
-            <el-select v-model="filter.level" placeholder="难度评级" style="width: 120px;" @change="all">
-              <el-option v-for="it in levels" :key="it.index" :label="it.label" :value="it.index" />
-            </el-select>
-          </el-form-item>
-          <el-form-item>
-            <el-select v-model="filter.tags" multiple filterable clearable placeholder="题目标签" style="width: 300px;"
-              @change="all">
-              <el-option v-for="tag in tagList" :key="tag" :label="tag" :value="tag">
-                <el-tag type="info" :color="getTagColor(tag)">
-                  <span class="tag-text">{{ tag }} </span>
-                </el-tag>
-              </el-option>
-            </el-select>
-          </el-form-item>
-        </el-form>
+
+      <!-- Filter bar -->
+      <div class="filter-bar">
+        <el-input v-model="pid" placeholder="pid跳转" style="width:80px"
+          @keyup.enter="$router.push('/problem/'+pid)" size="small" />
+        <el-input v-model="filter.name" placeholder="题目标题或内容" style="width:150px"
+          @keyup.enter="all" size="small" />
+        <el-select v-model="filter.publisherUid" filterable clearable placeholder="出题人"
+          style="width:130px" @change="all" size="small">
+          <el-option v-for="p in publisherList" :key="p.publisher" :label="p.name" :value="p.publisher" />
+        </el-select>
+        <el-select v-model="filter.level" placeholder="难度" style="width:100px" @change="all" size="small">
+          <el-option v-for="it in levels" :key="it.index" :label="it.label" :value="it.index" />
+        </el-select>
+        <el-select v-model="filter.tags" multiple filterable clearable placeholder="标签"
+          style="width:200px" @change="all" size="small">
+          <el-option v-for="tag in tagList" :key="tag" :label="tag" :value="tag">
+            <el-tag type="info" :color="getTagColor(tag)" size="small">
+              <span class="tag-text">{{ tag }}</span>
+            </el-tag>
+          </el-option>
+        </el-select>
         <el-button-group>
-          <el-button type="primary" @click="all">
-            筛选记录
-          </el-button>
-          <el-button type="success" @click="clear">
-            显示全部
-          </el-button>
+          <el-button type="primary" size="small" @click="all">筛选</el-button>
+          <el-button type="success" size="small" @click="clear">全部</el-button>
         </el-button-group>
+        <el-button plain size="small" round @click="switchTag">
+          {{ tagVisible ? '隐藏标签' : '显示标签' }}
+        </el-button>
       </div>
-      <el-table :data="problemList" height="600px" :header-cell-style="{ textAlign: 'center' }" :cell-style="cellStyle"
-        v-loading="!finished">
-        <el-table-column prop="pid" label="#" width="100px" />
-        <el-table-column prop="title" width="auto">
-          <template #header>
-            <div class="title-container">
-              <div class="title-left">标题</div>
-              <div class="tags-right">
-                <el-button plain size="small" round @click="switchTag">
-                  {{ tagVisible ? '隐藏标签' : '显示标签' }}
-                </el-button>
+
+      <!-- Table -->
+      <div class="table-scroll">
+        <el-table
+          :data="problemList"
+          height="600px"
+          :header-cell-style="{ textAlign:'center', background:'#f5f7fa' }"
+          :cell-style="cellStyle"
+          v-loading="!finished"
+          style="width:100%"
+        >
+          <el-table-column prop="pid" label="#" width="70" align="center" />
+          <el-table-column label="标题" min-width="220">
+            <template #default="scope">
+              <div class="title-cell">
+                <div class="title-left">
+                  <router-link class="rlink" :to="'/problem/'+scope.row.pid">{{ scope.row.title }}</router-link>
+                  <el-icon id="hidden" v-if="!scope.row.isPublic"><Hide /></el-icon>
+                </div>
+                <div class="tags-right" v-show="tagVisible">
+                  <el-tag
+                    v-for="tag in scope.row.tags" :key="tag"
+                    type="info" :color="getTagColor(tag)"
+                    size="small" @click="queryTag(tag)" style="cursor:pointer; margin-left:4px"
+                  >
+                    <span class="tag-text">{{ tag }}</span>
+                  </el-tag>
+                </div>
               </div>
-            </div>
-          </template>
-          <template #default="scope">
-            <div class="title-container">
-              <div class="title-left">
-                <router-link class="rlink" :to="'/problem/' + scope.row.pid">
-                  {{ scope.row.title }}
-                </router-link>
-                <el-icon id="hidden" v-if="!scope.row.isPublic">
-                  <Hide />
-                </el-icon>
-              </div>
-              <div class="tags-right">
-                <el-tag v-show="tagVisible" type="info" v-for="tag in scope.row.tags" :key="tag"
-                  :color="getTagColor(tag)" @click="queryTag(tag)">
-                  <span class="tag-text">{{ tag }} </span>
-                </el-tag>
-              </div>
-            </div>
-          </template>
-        </el-table-column>
-        <el-table-column prop="level" label="难度评级" width="150px">
-          <template #default="scope">
-            <el-button size="small" :color="levels[scope.row.level]?.color ?? '#BFBFBF'" :dark="true"
-              @click="filter.level = scope.row.level, all()">
-              <span class="tag-text"> {{ levels[scope.row.level]?.label ?? '未知难度' }} </span>
-            </el-button>
-          </template>
-        </el-table-column>
-        <el-table-column prop="status" label="AC/提交" width="120px">
-          <template #default="scope">
-            <span> {{ scope.row.acCnt }} / {{ scope.row.submitCnt }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="time" label="发布时间" width="120px" />
-        <el-table-column prop="publisher" label="出题人" width="160px">
-          <template #default="scope">
-            <router-link class="rlink" :to="'/user/' + scope.row.publisherUid">
-              {{ scope.row.publisher }}
-            </router-link>
-          </template>
-        </el-table-column>
-      </el-table>
+            </template>
+          </el-table-column>
+          <el-table-column label="难度" width="110" align="center">
+            <template #default="scope">
+              <el-button size="small" :color="levels[scope.row.level]?.color ?? '#BFBFBF'" :dark="true"
+                @click="filter.level=scope.row.level; all()">
+                <span class="tag-text">{{ levels[scope.row.level]?.label ?? '未知' }}</span>
+              </el-button>
+            </template>
+          </el-table-column>
+          <el-table-column label="AC/提交" width="90" align="center">
+            <template #default="scope">{{ scope.row.acCnt }} / {{ scope.row.submitCnt }}</template>
+          </el-table-column>
+          <el-table-column prop="time" label="发布" width="100" align="center" class-name="hide-on-mobile" />
+          <el-table-column label="出题人" width="120" align="center">
+            <template #default="scope">
+              <router-link class="rlink" :to="'/user/'+scope.row.publisherUid">{{ scope.row.publisher }}</router-link>
+            </template>
+          </el-table-column>
+        </el-table>
+      </div>
     </el-card>
   </div>
 </template>
 
 <script>
-import axios from "axios"
-import qs from 'qs'
+import axios from "axios";
+import qs from 'qs';
 
 export default {
   name: 'problemList',
   data() {
     return {
-      problemList: [],
-      total: 0,
-      gid: 1,
-      pid: '',
-      currentPage: 1,
-      finished: false,
-      filter: {
-        name: null,
-        level: null,
-        tags: [],
-        publisherUid: null
-      },
+      problemList: [], total: 0, gid: 1, pid: '',
+      currentPage: 1, finished: false,
+      filter: { name: null, level: null, tags: [], publisherUid: null },
       levels: [
-        {
-          index: 0,
-          label: '暂未评级',
-          color: '#BFBFBF'
-        },
-        {
-          index: 1,
-          label: '入门',
-          color: '#FE4C61'
-        },
-        {
-          index: 2,
-          label: '普及',
-          color: '#FFC116'
-        },
-        {
-          index: 3,
-          label: '提高',
-          color: '#52C41A'
-        },
-        {
-          index: 4,
-          label: '省选',
-          color: '#3498DB'
-        },
-        {
-          index: 5,
-          label: 'NOI / NOI+',
-          color: '#0E1D69'
-        },
-        {
-          index: 6,
-          label: '不限难度',
-        },
+        { index: 0, label: '暂未评级', color: '#BFBFBF' },
+        { index: 1, label: '入门',     color: '#FE4C61' },
+        { index: 2, label: '普及',     color: '#FFC116' },
+        { index: 3, label: '提高',     color: '#52C41A' },
+        { index: 4, label: '省选',     color: '#3498DB' },
+        { index: 5, label: 'NOI/NOI+', color: '#0E1D69' },
+        { index: 6, label: '不限难度'  },
       ],
-      tagColorList: [
-        '#2d8cf0',
-        '#3f51b5',
-        '#9c27b0',
-        '#009688',
-        '#19be6b',
-        '#689f38',
-        '#ff9900',
-        '#E91E63',
-        '#ed4014'
-      ],
-      tagList: [],
-      tagVisible: true,
-      publisherList: []
-    }
+      tagColorList: ['#2d8cf0','#3f51b5','#9c27b0','#009688','#19be6b','#689f38','#ff9900','#E91E63','#ed4014'],
+      tagList: [], tagVisible: true, publisherList: [],
+    };
   },
   methods: {
     all() {
@@ -206,147 +146,100 @@ export default {
       if (this.filter.level !== null) param.level = this.filter.level;
       if (this.filter.publisherUid) param.publisherUid = this.filter.publisherUid;
       if (this.filter.tags?.length) param.tags = JSON.stringify(this.filter.tags);
-      if (this.currentPage > 1)
-        param.pageId = this.currentPage;
-      let nurl = qs.stringify(param);
+      if (this.currentPage > 1) param.pageId = this.currentPage;
+      const nurl = qs.stringify(param);
       if (nurl) url += ('?' + nurl);
-      history.state.current = url;
       history.replaceState(history.state, null, url);
-      axios.post('/api/problem/getProblemList', {
-        pageId: this.currentPage,
-        filter: this.filter
-      }).then(res => {
-        this.problemList = res.data.data;
-        this.total = res.data.total;
-        this.finished = true;
-      }).catch(err => {
-        this.$message.error('获取题目列表失败' + err.message);
-      });
+      axios.post('/api/problem/getProblemList', { pageId: this.currentPage, filter: this.filter })
+        .then(res => { this.problemList = res.data.data; this.total = res.data.total; this.finished = true; })
+        .catch(err => { this.$message.error('获取题目列表失败 ' + err.message); });
     },
-    handleCurrentChange(val) {
-      this.currentPage = val;
-      this.all();
-    },
+    handleCurrentChange(val) { this.currentPage = val; this.all(); },
     addProblem() {
       axios.post('/api/problem/createProblem').then(res => {
-        if (res.status === 200) {
-          this.$router.push('/problem/edit/' + res.data.pid);
-        } else {
-          this.$message.error('添加题目失败' + res.data.message);
-        }
+        if (res.status === 200) this.$router.push('/problem/edit/' + res.data.pid);
+        else this.$message.error('添加题目失败 ' + res.data.message);
       });
     },
     cellStyle({ columnIndex }) {
       return { textAlign: columnIndex === 1 ? 'left' : 'center' };
     },
     clear() {
-      this.filter = {
-        name: null,
-        level: null,
-        tags: [],
-        publisherUid: null
-      };
+      this.filter = { name: null, level: null, tags: [], publisherUid: null };
       this.all();
     },
-    hash(str) {
-      let t = 0;
-      for (let i = 0; i < str.length; i++)
-        t = 31 * t + str.charCodeAt(i);
-      return t;
-    },
-    getTagColor(tag) {
-      return this.tagColorList[this.hash(tag) % this.tagColorList.length];
-    },
+    hash(str) { let t=0; for(let i=0;i<str.length;i++) t=31*t+str.charCodeAt(i); return t; },
+    getTagColor(tag) { return this.tagColorList[Math.abs(this.hash(tag)) % this.tagColorList.length]; },
     queryTag(tag) {
-      let list = this.filter.tags;
-      const index = list.indexOf(tag);
-      if (index !== -1) {
-        list.splice(index, 1);
-      } else {
-        list.push(tag);
-      }
+      const idx = this.filter.tags.indexOf(tag);
+      if (idx !== -1) this.filter.tags.splice(idx, 1); else this.filter.tags.push(tag);
       this.all();
     },
     switchTag() {
       this.tagVisible = !this.tagVisible;
       localStorage.setItem('tagVisible', this.tagVisible);
-    }
+    },
   },
   mounted() {
     if (localStorage.getItem('tagVisible') !== null)
       this.tagVisible = localStorage.getItem('tagVisible') === 'true';
     axios.post('/api/problem/getProblemTags').then(res => {
       if (res.status === 200) {
-        this.tagList = res.data;
-        this.tagList = this.tagList.sort((a, b) => {
-          return this.hash(a) % this.tagColorList.length - this.hash(b) % this.tagColorList.length;
-        });
-      } else {
-        this.$message.error('获取题目标签失败' + res.data.message);
+        this.tagList = res.data.sort((a,b) =>
+          Math.abs(this.hash(a)) % this.tagColorList.length - Math.abs(this.hash(b)) % this.tagColorList.length);
       }
     });
     axios.post('/api/problem/getProblemPublishers').then(res => {
-      if (res.status === 200) {
-        this.publisherList = res.data;
-      } else {
-        this.$message.error('获取出题人失败' + res.data.message);
-      }
+      if (res.status === 200) this.publisherList = res.data;
     });
     this.gid = this.$store.state.gid;
-    let query = this.$route.query;
-    if (query.name) this.filter.name = query.name;
-    if (query.level) this.filter.level = parseInt(query.level);
-    if (query.tags) this.filter.tags = JSON.parse(query.tags);
-    if (query.publisherUid) this.filter.publisherUid = parseInt(query.publisherUid);
-    if (query.pageId) this.currentPage = parseInt(query.pageId);
+    const q = this.$route.query;
+    if (q.name) this.filter.name = q.name;
+    if (q.level) this.filter.level = parseInt(q.level);
+    if (q.tags)  this.filter.tags  = JSON.parse(q.tags);
+    if (q.publisherUid) this.filter.publisherUid = parseInt(q.publisherUid);
+    if (q.pageId) this.currentPage = parseInt(q.pageId);
     this.all();
-  }
-}
+  },
+};
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.box-card {
-  height: auto;
-  margin: 10px;
-}
-
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 20px;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-weight: bolder;
+  color: #3f3f3f;
+}
+.card-title { font-size: 15px; }
+.card-header-right { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  align-items: center;
 }
 
-.title-container {
+.table-scroll { overflow-x: auto; }
+
+.title-cell {
   display: flex;
   justify-content: space-between;
   align-items: center;
-}
-
-.title-left {
-  display: flex;
-  align-items: center;
-}
-
-.tags-right {
-  display: flex;
-  justify-content: flex-end;
+  gap: 6px;
   flex-wrap: wrap;
 }
+.title-left { display: flex; align-items: center; gap: 4px; }
+.tags-right  { display: flex; flex-wrap: wrap; gap: 3px; }
 
-.el-tag {
-  cursor: pointer;
-  margin-left: 5px;
-}
-
-.tag-text {
-  color: white;
-  font-weight: 600;
-  font-size: 14px;
-}
-
-.el-form--inline .el-form-item {
-  margin-right: 15px;
+@media (max-width: 768px) {
+  .filter-bar > * { flex: 1 1 calc(50% - 4px); min-width: 0; }
+  .filter-bar .el-input,
+  .filter-bar .el-select { width: 100% !important; }
 }
 </style>

--- a/web/src/components/problem/problemView.vue
+++ b/web/src/components/problem/problemView.vue
@@ -1,290 +1,198 @@
 <template>
-  <el-row style="margin: auto;max-width: 1500px;min-width: 600px;">
-    <el-col :xs="24" :sm="24" :md="17">
-      <el-card class="box-card" shadow="hover">
-        <template #header>
-          <div class="card-header" style="height: 35px;">
-            <p class="title">
-              #{{ problemInfo.pid }}、{{ problemInfo.title }}
-              <el-icon id="hidden" v-if="!problemInfo.isPublic">
-                <Hide />
-              </el-icon>
-            </p>
-          </div>
-        </template>
-        <div v-if="isSubmit">
-          <div style="margin: 10px;">
-            选择语言：
-            <el-select v-model="submitLang" placeholder="选择语言" style="width: 160px;">
-              <el-option v-for="l in this.langList" :key="l.id" :label="l.des" :value="l.id" />
-            </el-select>
-          </div>
-          <el-divider />
-          <monacoEditor :value="code" :language="$store.state.langList[submitLang].lang"
-            @update:value="code = $event" />
-          <el-divider />
-          <div style="text-align: center;">
-            <el-button type="primary" @click="submit">
-              <el-icon class="el-icon--left">
-                <Upload />
-              </el-icon>
-              确认提交
-            </el-button>
-          </div>
-        </div>
-        <v-md-preview v-show="!isSubmit" :text="problemInfo.description"> </v-md-preview>
-      </el-card>
-    </el-col>
-    <el-col :xs="24" :sm="24" :md="7">
-      <el-card class="box-card" shadow="hover">
-        <template #header>
-          <div class="card-header">
-            <div class="stat-item clickable"
-              @click="this.$router.push({ path: '/submission', query: { pid: pid, res: 4, queryAll: true } })">
-              <div class="stat-number">{{ problemInfo.acCnt }}</div>
-              <div class="stat-label">通过</div>
+  <div class="page-wrap page-wrap--sub">
+    <el-row :gutter="12">
+      <!-- Main: problem content -->
+      <el-col :xs="24" :md="17" class="col-main">
+        <el-card shadow="hover">
+          <template #header>
+            <div class="card-header prob-title-header">
+              <h1 class="prob-title">
+                #{{ problemInfo.pid }}、{{ problemInfo.title }}
+                <el-icon id="hidden" v-if="!problemInfo.isPublic"><Hide /></el-icon>
+              </h1>
             </div>
-            <div class="stat-divider"></div>
-            <div class="stat-item clickable"
-              @click="this.$router.push({ path: '/submission', query: { pid: pid, queryAll: true } })">
-              <div class="stat-number">{{ problemInfo.submitCnt }}</div>
-              <div class="stat-label">提交</div>
+          </template>
+
+          <!-- Problem description -->
+          <v-md-preview v-show="!isSubmit" :text="problemInfo.description" />
+
+          <!-- Submit panel -->
+          <div v-if="isSubmit" class="submit-panel">
+            <div class="submit-lang">
+              <span>选择语言：</span>
+              <el-select v-model="submitLang" placeholder="选择语言" style="width:180px">
+                <el-option v-for="l in langList" :key="l.id" :label="l.des" :value="l.id" />
+              </el-select>
+            </div>
+            <el-divider />
+            <monacoEditor
+              :value="code"
+              :language="$store.state.langList[submitLang]?.lang ?? 'cpp'"
+              @update:value="code = $event"
+            />
+            <el-divider />
+            <div class="submit-actions">
+              <el-button type="primary" @click="submit">
+                <el-icon class="el-icon--left"><Upload /></el-icon>确认提交
+              </el-button>
+              <el-button @click="isSubmit = false">
+                <el-icon class="el-icon--left"><RefreshLeft /></el-icon>查看题目
+              </el-button>
             </div>
           </div>
-        </template>
-        <el-descriptions direction="vertical" :column="1" border>
-          <el-descriptions-item label="时间限制"> {{ problemInfo.timeLimit }} ms</el-descriptions-item>
-          <el-descriptions-item label="空间限制"> {{ problemInfo.memoryLimit }} MB</el-descriptions-item>
-          <el-descriptions-item label="比对方式"> {{ problemInfo.type }} </el-descriptions-item>
-          <el-descriptions-item label="题目标签">
-            <el-tag type="info" v-for="tag in problemInfo.tags" :key="tag" :color="getTagColor(tag)"
-              @click="this.$router.push({ path: '/problem', query: { tags: JSON.stringify([tag]) } })">
-              <span class="tag-text">{{ tag }} </span>
-            </el-tag>
-          </el-descriptions-item>
-          <el-descriptions-item label="难度评级">
-            <el-button size="small" :color="levels[problemInfo.level]?.color ?? '#BFBFBF'" :dark="true"
-              @click="this.$router.push({ path: '/problem', query: { level: problemInfo.level } })">
-              <span style="color: white; font-weight: 600; font-size: 14px;">
-                {{ levels[problemInfo.level]?.label ?? '未知难度' }} </span>
+        </el-card>
+      </el-col>
+
+      <!-- Sidebar -->
+      <el-col :xs="24" :md="7" class="col-sidebar">
+        <el-card shadow="hover">
+          <!-- AC / Submit stats -->
+          <template #header>
+            <div class="stat-header">
+              <div class="stat-item clickable"
+                @click="$router.push({ path:'/submission', query:{ pid, res:4, queryAll:true } })">
+                <div class="stat-num">{{ problemInfo.acCnt }}</div>
+                <div class="stat-lbl">通过</div>
+              </div>
+              <div class="stat-divider"></div>
+              <div class="stat-item clickable"
+                @click="$router.push({ path:'/submission', query:{ pid, queryAll:true } })">
+                <div class="stat-num">{{ problemInfo.submitCnt }}</div>
+                <div class="stat-lbl">提交</div>
+              </div>
+            </div>
+          </template>
+
+          <el-descriptions direction="vertical" :column="1" border size="small">
+            <el-descriptions-item label="时间限制">{{ problemInfo.timeLimit }} ms</el-descriptions-item>
+            <el-descriptions-item label="空间限制">{{ problemInfo.memoryLimit }} MB</el-descriptions-item>
+            <el-descriptions-item label="比对方式">{{ problemInfo.type }}</el-descriptions-item>
+            <el-descriptions-item label="难度评级">
+              <el-button size="small" :color="levels[problemInfo.level]?.color ?? '#BFBFBF'" :dark="true"
+                @click="$router.push({ path:'/problem', query:{ level: problemInfo.level } })">
+                <span class="tag-text">{{ levels[problemInfo.level]?.label ?? '未知' }}</span>
+              </el-button>
+            </el-descriptions-item>
+            <el-descriptions-item label="题目标签">
+              <el-tag
+                type="info" v-for="tag in problemInfo.tags" :key="tag"
+                :color="getTagColor(tag)" size="small" style="margin:2px; cursor:pointer"
+                @click="$router.push({ path:'/problem', query:{ tags: JSON.stringify([tag]) } })">
+                <span class="tag-text">{{ tag }}</span>
+              </el-tag>
+            </el-descriptions-item>
+            <el-descriptions-item label="出题人">
+              <router-link class="rlink" :to="'/user/'+problemInfo.publisherUid">{{ problemInfo.publisher }}</router-link>
+            </el-descriptions-item>
+            <el-descriptions-item label="发布时间">{{ problemInfo.time }}</el-descriptions-item>
+          </el-descriptions>
+
+          <el-divider />
+
+          <div class="sidebar-actions">
+            <el-button v-if="!isSubmit" type="primary" @click="isSubmit = true">
+              <el-icon class="el-icon--left"><Upload /></el-icon>提交代码
             </el-button>
-          </el-descriptions-item>
-          <el-descriptions-item label="出题人">
-            <router-link class="rlink" :to="'/user/' + problemInfo.publisherUid">
-              {{ problemInfo.publisher }}
-            </router-link>
-          </el-descriptions-item>
-          <el-descriptions-item label="发布时间"> {{ problemInfo.time }} </el-descriptions-item>
-        </el-descriptions>
-        <el-divider style="margin-top: 20px; margin-bottom: 20px;" />
-        <div style="text-align: center;">
-          <el-button v-if="!this.isSubmit" type="primary" @click="this.isSubmit = true">
-            <el-icon class="el-icon--left">
-              <Upload />
-            </el-icon>
-            提交代码
-          </el-button>
-          <el-button v-if="this.isSubmit" type="success" @click="this.isSubmit = false">
-            <el-icon class="el-icon--left">
-              <RefreshLeft />
-            </el-icon>
-            查看题目
-          </el-button>
-          <el-button color="#626aef" @click="this.$router.push('/problem/stat/' + problemInfo.pid)">
-            <el-icon class="el-icon--left">
-              <Histogram />
-            </el-icon>
-            数据统计
-          </el-button>
-          <el-button v-if="this.gid > 1" type="danger" @click="this.$router.push('/problem/edit/' + problemInfo.pid)">
-            <el-icon class="el-icon--left">
-              <Operation />
-            </el-icon>
-            题目管理
-          </el-button>
-        </div>
-      </el-card>
-    </el-col>
-  </el-row>
+            <el-button v-if="isSubmit" type="success" @click="isSubmit = false">
+              <el-icon class="el-icon--left"><RefreshLeft /></el-icon>查看题目
+            </el-button>
+            <el-button color="#626aef"
+              @click="$router.push('/problem/stat/'+problemInfo.pid)">
+              <el-icon class="el-icon--left"><Histogram /></el-icon>统计
+            </el-button>
+            <el-button v-if="gid > 1" type="danger"
+              @click="$router.push('/problem/edit/'+problemInfo.pid)">
+              <el-icon class="el-icon--left"><Operation /></el-icon>管理
+            </el-button>
+          </div>
+        </el-card>
+      </el-col>
+    </el-row>
+  </div>
 </template>
 
 <script>
 import axios from 'axios';
-import monacoEditor from '@/components/monacoEditor.vue'
+import monacoEditor from '@/components/monacoEditor.vue';
 
 export default {
   name: "problemView",
+  components: { monacoEditor },
   data() {
     return {
-      pid: 0,
-      gid: 1,
-      submitLang: null,
-      langList: [],
-      problemInfo: {},
-      code: '',
-      isSubmit: false,
+      pid: 0, gid: 1, submitLang: null, langList: [],
+      problemInfo: {}, code: '', isSubmit: false,
       levels: [
-        {
-          label: '暂未评级',
-          color: '#BFBFBF'
-        },
-        {
-          label: '入门',
-          color: '#FE4C61'
-        },
-        {
-          label: '普及',
-          color: '#FFC116'
-        },
-        {
-          label: '提高',
-          color: '#52C41A'
-        },
-        {
-          label: '省选',
-          color: '#3498DB'
-        },
-        {
-          label: 'NOI / NOI+',
-          color: '#0E1D69'
-        },
+        { label: '暂未评级', color: '#BFBFBF' }, { label: '入门',     color: '#FE4C61' },
+        { label: '普及',     color: '#FFC116' }, { label: '提高',     color: '#52C41A' },
+        { label: '省选',     color: '#3498DB' }, { label: 'NOI/NOI+', color: '#0E1D69' },
       ],
-      tagColorList: [
-        '#2d8cf0',
-        '#3f51b5',
-        '#9c27b0',
-        '#009688',
-        '#19be6b',
-        '#689f38',
-        '#ff9900',
-        '#E91E63',
-        '#ed4014'
-      ],
-    }
-  },
-  components: {
-    monacoEditor
+      tagColorList: ['#2d8cf0','#3f51b5','#9c27b0','#009688','#19be6b','#689f38','#ff9900','#E91E63','#ed4014'],
+    };
   },
   methods: {
     submit() {
-      axios.post('/api/judge/submit', {
-        pid: this.pid,
-        code: this.code,
-        lang: this.submitLang
-      }).then(res => {
-        if (res.status === 200) {
-          this.$router.push('/submission/' + res.data.sid);
-        } else {
-          this.$message.error('提交失败' + res.data.message);
-        }
-      });
+      axios.post('/api/judge/submit', { pid: this.pid, code: this.code, lang: this.submitLang })
+        .then(res => {
+          if (res.status === 200) this.$router.push('/submission/' + res.data.sid);
+          else this.$message.error('提交失败 ' + res.data.message);
+        });
     },
-    hash(str) {
-      let t = 0;
-      for (let i = 0; i < str.length; i++)
-        t = 31 * t + str.charCodeAt(i);
-      return t;
-    },
-    getTagColor(tag) {
-      return this.tagColorList[this.hash(tag) % this.tagColorList.length];
-    },
+    hash(str) { let t=0; for(let i=0;i<str.length;i++) t=31*t+str.charCodeAt(i); return t; },
+    getTagColor(tag) { return this.tagColorList[Math.abs(this.hash(tag)) % this.tagColorList.length]; },
   },
   async mounted() {
     this.pid = this.$route.params.pid;
     this.gid = this.$store.state.gid;
     await axios.post('/api/problem/getProblemInfo', { pid: this.pid }).then(res => {
       if (res.status === 200) {
-        this.problemInfo = res.data.data
-        this.problemInfo.isPublic = res.data.data.isPublic ? true : false;
+        this.problemInfo = res.data.data;
+        this.problemInfo.isPublic = !!res.data.data.isPublic;
         for (let l in this.$store.state.langList) {
-          let lid = this.$store.state.langList[l].id;
+          const lid = this.$store.state.langList[l].id;
           if ((1 << lid) & this.problemInfo.lang) {
             this.langList.push(this.$store.state.langList[l]);
-            if (!this.submitLang)
-              this.submitLang = lid;
-            if (lid === this.$store.state.preferenceLang)
-              this.submitLang = lid;
+            if (!this.submitLang) this.submitLang = lid;
+            if (lid === this.$store.state.preferenceLang) this.submitLang = lid;
           }
         }
-        if (!this.$store.state.preferenceLang)
-          this.$message.info('可在编辑资料--个人信息中设置您的偏好语言');
-        else if (this.submitLang !== this.$store.state.preferenceLang)
-          this.$message.warning('本题无法用您的偏好语言提交');
-      }
-      else {
-        this.$router.push({ path: '/problem' });
-        this.$message.error(res.data.message)
+        document.title = '题目 — ' + this.problemInfo.title;
+      } else {
+        this.$router.push('/problem');
+        this.$message.error(res.data.message);
       }
     });
-    document.title = "题目 — " + this.problemInfo.title;
-  }
-}
+  },
+};
 </script>
 
 <style scoped>
-.box-card {
-  margin: 10px;
-  text-align: left;
-}
+.col-main, .col-sidebar { margin-bottom: 12px; }
 
-.card-header {
+.prob-title-header { padding: 4px 0; }
+.prob-title { margin: 0; font-size: 22px; font-weight: 800; color: #2c3e50; }
+
+.stat-header {
   display: flex;
   align-items: center;
   justify-content: space-around;
+  padding: 4px 0;
 }
+.stat-item { text-align: center; flex: 1; }
+.stat-num  { font-size: 26px; font-weight: 700; color: #303133; }
+.stat-lbl  { font-size: 13px; color: #909399; margin-top: 2px; }
+.stat-divider { width: 1px; height: 50px; background: #e0e0e0; margin: 0 12px; }
+.clickable { cursor: pointer; border-radius: 6px; transition: background 0.2s; }
+.clickable:hover { background: #f5f7fa; }
 
-.stat-item {
-  text-align: center;
-  flex: 1;
-}
+.submit-panel { padding-top: 4px; }
+.submit-lang  { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; font-size: 14px; }
+.submit-actions { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
 
-.clickable {
-  cursor: pointer;
-  transition: background-color 0.3s;
-  border-radius: 5px;
-}
-
-.clickable:hover {
-  background-color: #f5f7fa;
-}
-
-.stat-number {
-  font-size: 28px;
-  font-weight: bold;
-  color: #303133;
-}
-
-.stat-label {
-  font-size: 14px;
-  color: #909399;
-  margin-top: 3px;
-}
-
-.stat-divider {
-  width: 1px;
-  height: 60px;
-  background-color: #e0e0e0;
-  margin: 0 20px;
-}
-
-.title {
-  margin: 0;
-  font-size: 25px;
-}
-
-.el-tag {
-  cursor: pointer;
-  margin-right: 5px;
-}
-
-.tag-text {
-  color: white;
-  font-weight: 600;
-  font-size: 14px;
-}
-
-#hidden {
-  vertical-align: -4px;
-  color: #312b2b;
+.sidebar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
 }
 </style>

--- a/web/src/components/submission/submissionList.vue
+++ b/web/src/components/submission/submissionList.vue
@@ -1,287 +1,198 @@
 <template>
-  <div style="text-align: center; margin: 0 auto; max-width: 1400px">
-    <el-card class="box-card" shadow="hover">
+  <div class="page-wrap page-wrap--md">
+    <el-card shadow="hover">
       <template #header>
-        <div class="card-header">
-          评测列表
-          <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
-            layout="total, prev, pager, next" :total="total"></el-pagination>
-          <el-button-group>
-            <el-button type="success" @click="mySub">
-              <el-icon class="el-icon--left">
-                <UserFilled />
-              </el-icon>
-              我的提交
-            </el-button>
-            <el-button type="primary" @click="all">
-              <el-icon class="el-icon--left">
-                <Refresh />
-              </el-icon>
-              刷新
-            </el-button>
-          </el-button-group>
+        <div class="card-header card-header--wrap">
+          <span class="card-title">评测列表</span>
+          <div class="card-header-right">
+            <el-pagination small @current-change="handleCurrentChange"
+              :current-page="currentPage" :page-size="20"
+              layout="total, prev, pager, next" :total="total" hide-on-single-page />
+            <el-button-group>
+              <el-button type="success" size="small" @click="mySub">
+                <el-icon class="el-icon--left"><UserFilled /></el-icon>我的提交
+              </el-button>
+              <el-button type="primary" size="small" @click="all">
+                <el-icon class="el-icon--left"><Refresh /></el-icon>刷新
+              </el-button>
+            </el-button-group>
+          </div>
         </div>
       </template>
-      <div style="display: inline-flex;">
-        <el-form :inline="true" :model="filter">
-          <el-form-item>
-            <el-input v-model="filter.pid" type="text" placeholder="题目编号" style="width: 100px;" @keyup.enter="all" />
-          </el-form-item>
-          <el-form-item>
-            <el-input v-model="filter.name" type="text" placeholder="用户名" style="width: 150px;" @keyup.enter="all" />
-          </el-form-item>
-          <el-form-item>
-            <el-input v-model="filter.score" type="text" placeholder="分数" style="width: 100px;" @keyup.enter="all" />
-          </el-form-item>
-          <el-form-item>
-            <el-select v-model="filter.res" placeholder="评测结果" style="width: 200px;">
-              <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
-            </el-select>
-          </el-form-item>
-          <el-form-item>
-            <el-select v-model="filter.lang" placeholder="提交语言" style="width: 160px;">
-              <el-option v-for="l in $store.state.langList" :key="l.id" :label="l.des" :value="l.id" />
-            </el-select>
-          </el-form-item>
-          <el-form-item v-if="queryAll">
-            <el-input v-model="filter.cid" type="text" placeholder="比赛id" style="width: 80px;" @keyup.enter="all" />
-          </el-form-item>
-        </el-form>
-        <span v-if="this.$store.state.gid >= 2" style="font-size: 14px; font-weight: 600; margin:0 20px 0 10px;">
+
+      <!-- Filter bar -->
+      <div class="filter-bar">
+        <el-input v-model="filter.pid"  placeholder="题目编号" style="width:100px" @keyup.enter="all" size="small" />
+        <el-input v-model="filter.name" placeholder="用户名"   style="width:120px" @keyup.enter="all" size="small" />
+        <el-input v-model="filter.score" placeholder="分数"    style="width:80px"  @keyup.enter="all" size="small" />
+        <el-select v-model="filter.res"  placeholder="评测结果" style="width:180px" size="small">
+          <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+        </el-select>
+        <el-select v-model="filter.lang" placeholder="提交语言" style="width:140px" size="small">
+          <el-option v-for="l in $store.state.langList" :key="l.id" :label="l.des" :value="l.id" />
+        </el-select>
+        <el-input v-if="queryAll" v-model="filter.cid" placeholder="比赛id" style="width:80px" size="small" />
+        <span v-if="$store.state.gid >= 2" class="toggle-label">
           比赛提交：
-          <el-switch v-model="queryAll" class="mb-2" active-text="显示" inactive-text="隐藏" @change="all" />
+          <el-switch v-model="queryAll" active-text="显示" inactive-text="隐藏" @change="all" />
         </span>
         <el-button-group>
-          <el-button type="primary" @click="this.all">
-            筛选记录
-          </el-button>
-          <el-button type="success" @click="clear">
-            显示全部
-          </el-button>
+          <el-button type="primary" size="small" @click="all">筛选</el-button>
+          <el-button type="success" size="small" @click="clear">全部</el-button>
         </el-button-group>
       </div>
-      <el-table :data="submissionList" height="600px" :header-cell-style="{ textAlign: 'center' }"
-        :cell-style="cellStyle" :row-class-name="tableRowClassName" v-loading="!finished">
-        <el-table-column prop="sid" label="#" width="100px" />
-        <el-table-column prop="title" label="题目" min-width="200px">
-          <template #default="scope">
-            <router-link class="rlink" :to="'/problem/' + scope.row.pid">
-              {{ scope.row.title }}
-            </router-link>
-            <el-icon id="hidden" v-if="!scope.row.isPublic">
-              <Hide />
-            </el-icon>
-          </template>
-        </el-table-column>
-        <el-table-column prop="name" label="提交者" width="150px">
-          <template #default="scope">
-            <router-link class="rlink" :to="'/user/' + scope.row.uid">
-              {{ scope.row.name }}
-            </router-link>
-          </template>
-        </el-table-column>
-        <el-table-column prop="judgeResult" label="评测状态" width="160px">
-          <template #default="scope">
-            <span style="cursor: pointer;" @click="go2s(scope)">
-              {{ scope.row.judgeResult }}
-            </span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="score" label="分数" width="80px">
-          <template #default="scope">
-            <span> {{ scope.row.score }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="judgeResult" label="总用时" width="100px">
-          <template #default="scope">
-            <span> {{ scope.row.time }} ms</span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="judgeResult" label="内存" width="100px">
-          <template #default="scope">
-            <span> {{ scope.row.memory }} </span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="codeLength" label="语言 / 代码长度" width="150px">
-          <template #default="scope">
-            <span>{{ $store.state.langList[scope.row.lang].des }} / {{ scope.row.codeLength }} B </span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="submitTime" label="提交时间" fixed="right" width="160px" />
-        <el-table-column prop="machine" label="评测机" fixed="right" min-width="100px" />
-      </el-table>
+
+      <div class="table-scroll">
+        <el-table
+          :data="submissionList"
+          height="600px"
+          :header-cell-style="{ textAlign:'center', background:'#f5f7fa' }"
+          :cell-style="cellStyle"
+          :row-class-name="tableRowClassName"
+          v-loading="!finished"
+          style="width:100%; min-width:700px"
+        >
+          <el-table-column prop="sid" label="#" width="70" align="center" />
+          <el-table-column label="题目" min-width="160">
+            <template #default="scope">
+              <router-link class="rlink" :to="'/problem/'+scope.row.pid">{{ scope.row.title }}</router-link>
+              <el-icon id="hidden" v-if="!scope.row.isPublic"><Hide /></el-icon>
+            </template>
+          </el-table-column>
+          <el-table-column label="提交者" width="110" align="center">
+            <template #default="scope">
+              <router-link class="rlink" :to="'/user/'+scope.row.uid">{{ scope.row.name }}</router-link>
+            </template>
+          </el-table-column>
+          <el-table-column label="评测状态" width="160" align="center">
+            <template #default="scope">
+              <span style="cursor:pointer" @click="go2s(scope)">{{ scope.row.judgeResult }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column prop="score" label="分数" width="70" align="center" />
+          <el-table-column label="用时" width="90" align="center" class-name="hide-on-mobile">
+            <template #default="scope">{{ scope.row.time }} ms</template>
+          </el-table-column>
+          <el-table-column label="内存" width="90" align="center" class-name="hide-on-mobile">
+            <template #default="scope">{{ scope.row.memory }}</template>
+          </el-table-column>
+          <el-table-column label="语言" width="140" align="center" class-name="hide-on-mobile">
+            <template #default="scope">
+              {{ $store.state.langList[scope.row.lang]?.des }} / {{ scope.row.codeLength }} B
+            </template>
+          </el-table-column>
+          <el-table-column prop="submitTime" label="提交时间" width="155" align="center" fixed="right" />
+          <el-table-column prop="machine"    label="评测机"   width="90"  align="center" fixed="right" class-name="hide-on-mobile" />
+        </el-table>
+      </div>
     </el-card>
   </div>
 </template>
 
 <script>
-import axios from "axios"
-import { resColor, scoreColor } from '@/assets/common'
-import qs from 'qs'
+import axios from "axios";
+import { resColor, scoreColor } from '@/assets/common';
+import qs from 'qs';
 
 export default {
   name: 'submissionList',
   data() {
     return {
-      submissionList: [],
-      total: 0,
-      finished: false,
-      currentPage: 1,
-      filter: {
-        pid: null,
-        name: null,
-        res: null,
-        score: null,
-        cid: null,
-        lang: null
-      },
+      submissionList: [], total: 0, finished: false, currentPage: 1,
+      filter: { pid: null, name: null, res: null, score: null, cid: null, lang: null },
       queryAll: false,
-      options: [{
-        value: -1,
-        label: '不限结果',
-      }, {
-        value: 4,
-        label: 'Accepted',
-      }, {
-        value: 5,
-        label: 'Wrong Answer',
-      }, {
-        value: 6,
-        label: 'Time Limit Exceeded',
-      }, {
-        value: 7,
-        label: 'Memory Limit Exceeded',
-      }, {
-        value: 8,
-        label: 'Runtime Error',
-      }, {
-        value: 9,
-        label: 'Segmentation Fault',
-      }, {
-        value: 3,
-        label: 'Compilation Error',
-      }, {
-        value: 10,
-        label: 'Output Limit Exceeded',
-      }, {
-        value: 0,
-        label: 'Waiting',
-      }, {
-        value: 1,
-        label: 'Pending',
-      }, {
-        value: 2,
-        label: 'Rejudging',
-      }, {
-        value: 11,
-        label: 'Dangerous System Call',
-      }, {
-        value: 12,
-        label: 'System Error',
-      }, {
-        value: 13,
-        label: 'Canceled',
-      }],
-    }
+      options: [
+        { value: -1, label: '不限结果' }, { value: 4,  label: 'Accepted'              },
+        { value: 5,  label: 'Wrong Answer'              }, { value: 6,  label: 'Time Limit Exceeded'    },
+        { value: 7,  label: 'Memory Limit Exceeded'     }, { value: 8,  label: 'Runtime Error'          },
+        { value: 9,  label: 'Segmentation Fault'        }, { value: 3,  label: 'Compilation Error'      },
+        { value: 10, label: 'Output Limit Exceeded'     }, { value: 0,  label: 'Waiting'                },
+        { value: 1,  label: 'Pending'                   }, { value: 2,  label: 'Rejudging'              },
+        { value: 11, label: 'Dangerous System Call'     }, { value: 12, label: 'System Error'           },
+        { value: 13, label: 'Canceled'                  },
+      ],
+    };
   },
   methods: {
     all() {
       this.finished = false;
       let param = {}, url = location.pathname;
-      if (this.filter.name) param.name = this.filter.name;
-      if (this.filter.pid) param.pid = this.filter.pid;
-      if (this.filter.cid) param.cid = this.filter.cid;
+      if (this.filter.name)  param.name  = this.filter.name;
+      if (this.filter.pid)   param.pid   = this.filter.pid;
+      if (this.filter.cid)   param.cid   = this.filter.cid;
       if (this.filter.score !== null) param.score = this.filter.score;
-      if (this.filter.res !== null) param.res = this.filter.res;
-      if (this.filter.lang !== null) param.lang = this.filter.lang;
+      if (this.filter.res   !== null) param.res   = this.filter.res;
+      if (this.filter.lang  !== null) param.lang  = this.filter.lang;
       if (this.queryAll && this.$store.state.gid > 1) param.queryAll = true;
-      if (this.currentPage > 1)
-        param.pageId = this.currentPage;
-      let nurl = qs.stringify(param);
+      if (this.currentPage > 1) param.pageId = this.currentPage;
+      const nurl = qs.stringify(param);
       if (nurl) url += ('?' + nurl);
-      history.state.current = url;
       history.replaceState(history.state, null, url);
       axios.post('/api/judge/getSubmissionList', {
-        pageId: this.currentPage,
-        pid: this.filter.pid,
-        cid: this.filter.cid,
-        name: this.filter.name,
-        score: this.filter.score,
-        judgeRes: (this.filter.res === -1 ? null : this.filter.res),
-        lang: this.filter.lang,
-        queryAll: this.queryAll
+        pageId: this.currentPage, pid: this.filter.pid, cid: this.filter.cid,
+        name: this.filter.name, score: this.filter.score,
+        judgeRes: this.filter.res === -1 ? null : this.filter.res,
+        lang: this.filter.lang, queryAll: this.queryAll,
       }).then(res => {
         this.submissionList = res.data.data;
         this.total = res.data.total;
         this.finished = true;
-      }).catch(err => {
-        this.$message.error('获取提交记录失败' + err.message);
-      });
+      }).catch(err => { this.$message.error('获取提交记录失败 ' + err.message); });
     },
     clear() {
-      this.filter.name = this.filter.pid = this.filter.res = this.filter.score = this.filter.cid = this.filter.lang = null;
+      this.filter = { pid: null, name: null, res: null, score: null, cid: null, lang: null };
       this.all();
     },
-    mySub() {
-      this.filter.name = this.$store.state.name;
-      this.all();
-    },
-    handleCurrentChange(val) {
-      this.currentPage = val;
-      this.all();
-    },
-    tableRowClassName(obj) {
-      return (obj.row.cid ? 'warning' : '');
-    },
+    mySub() { this.filter.name = this.$store.state.name; this.all(); },
+    handleCurrentChange(val) { this.currentPage = val; this.all(); },
+    tableRowClassName({ row }) { return row.cid ? 'warning' : ''; },
     go2s(scope) {
-      if (!scope.row.cid)
-        this.$router.push('/submission/' + scope.row.sid);
-      else
-        this.$router.push({ path: '/submission/' + scope.row.sid, query: { isContest: true } })
+      if (!scope.row.cid) this.$router.push('/submission/' + scope.row.sid);
+      else this.$router.push({ path: '/submission/' + scope.row.sid, query: { isContest: true } });
     },
     cellStyle({ row, columnIndex }) {
-      let style = {};
-      style['textAlign'] = 'center';
-      if (columnIndex === 3) {
-        style['font-weight'] = 500;
-        style['color'] = resColor[row.judgeResult];
-      }
-      if (columnIndex === 4) {
-        style['font-weight'] = 500;
-        style['color'] = scoreColor[Math.floor(row.score / 10)];
-      }
-      return style;
+      const s = { textAlign: 'center' };
+      if (columnIndex === 3) { s.fontWeight = 500; s.color = resColor[row.judgeResult]; }
+      if (columnIndex === 4) { s.fontWeight = 500; s.color = scoreColor[Math.floor(row.score / 10)]; }
+      return s;
     },
   },
   mounted() {
-    let query = this.$route.query;
-    if (query.res) this.filter.res = parseInt(query.res);
-    if (query.score) this.filter.score = parseInt(query.score);
-    if (query.name) this.filter.name = query.name;
-    if (query.pid) this.filter.pid = query.pid;
-    if (query.cid) this.filter.cid = query.cid;
-    if (query.lang) this.filter.lang = parseInt(query.lang);
-    if (query.queryAll && this.$store.state.gid > 1) this.queryAll = true;
-    if (query.pageId) this.currentPage = parseInt(query.pageId);
+    const q = this.$route.query;
+    if (q.res)   this.filter.res   = parseInt(q.res);
+    if (q.score) this.filter.score = parseInt(q.score);
+    if (q.name)  this.filter.name  = q.name;
+    if (q.pid)   this.filter.pid   = q.pid;
+    if (q.cid)   this.filter.cid   = q.cid;
+    if (q.lang)  this.filter.lang  = parseInt(q.lang);
+    if (q.queryAll && this.$store.state.gid > 1) this.queryAll = true;
+    if (q.pageId) this.currentPage = parseInt(q.pageId);
     this.all();
-  }
-}
+  },
+};
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.box-card {
-  margin: 10px;
-}
-
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 20px;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-weight: bolder;
+  color: #3f3f3f;
 }
+.card-title { font-size: 15px; }
+.card-header-right { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 
-.el-form--inline .el-form-item {
-  margin-right: 15px;
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  align-items: center;
 }
+.toggle-label { font-size: 13px; font-weight: 600; display: flex; align-items: center; gap: 6px; }
+
+.table-scroll { overflow-x: auto; }
 </style>

--- a/web/src/components/user/edit/userProfile.vue
+++ b/web/src/components/user/edit/userProfile.vue
@@ -1,55 +1,64 @@
 <template>
-  <div style="margin: 0 20px;">
-    <el-row>
-      <el-col :span="16">
-        <div class="header">
-          个人信息
-        </div>
+  <div class="profile-wrap">
+    <el-row :gutter="24">
+      <el-col :xs="24" :sm="16">
+        <div class="section-title">个人信息</div>
         <el-divider />
-        <el-form label-position="top">
+        <el-form label-position="top" class="profile-form">
           <el-form-item label="用户名">
-            <el-input v-model="userInfo.name" type="text" :disabled="true" />
+            <el-input v-model="userInfo.name" disabled />
             <span class="attach">请联系超级管理员修改用户名</span>
           </el-form-item>
           <el-form-item label="邮箱">
-            <el-input v-model="userInfo.email" type="text" :disabled="true" />
+            <el-input v-model="userInfo.email" disabled />
             <span class="attach">请在「账号安全」中修改邮箱</span>
           </el-form-item>
           <el-form-item label="偏好语言">
-            <el-select v-model="userInfo.preferenceLang" placeholder="选择语言">
-              <el-option v-for="l in this.$store.state.langList" :key="l.id" :label="l.des" :value="l.id" />
+            <el-select v-model="userInfo.preferenceLang" placeholder="选择语言" style="width:100%">
+              <el-option v-for="l in $store.state.langList" :key="l.id" :label="l.des" :value="l.id" />
             </el-select>
           </el-form-item>
-          <el-form-item label="qq号">
-            <el-input v-model="userInfo.qq" type="text" />
-            <span class="attach">OJ头像将使用qq头像</span>
+          <el-form-item label="QQ 号">
+            <el-input v-model="userInfo.qq" placeholder="输入 QQ 号，头像将同步" />
+            <span class="attach">OJ 头像将使用 QQ 头像</span>
           </el-form-item>
           <el-form-item label="个人主页">
-            <el-input v-model="userInfo.motto" type="textarea" :rows="10" :maxlength="1000" :show-word-limit="true"
-              resize="none" />
+            <el-input
+              v-model="userInfo.motto"
+              type="textarea"
+              :rows="8"
+              :maxlength="1000"
+              show-word-limit
+              resize="none"
+              placeholder="写点什么介绍自己…"
+            />
+          </el-form-item>
+          <el-form-item>
+            <el-button type="primary" @click="submit">保存修改</el-button>
           </el-form-item>
         </el-form>
-        <el-button type="primary" @click="submit">提交</el-button>
       </el-col>
-      <el-col :span="8">
-        <div style="margin: 0 20px;">
-          <el-avatar shape="square" :size="250" :src="avatarAddress" />
+
+      <el-col :xs="24" :sm="8">
+        <div class="avatar-col">
+          <el-avatar shape="square" :size="180" :src="avatarAddress" class="avatar-img" />
+          <p class="attach" style="text-align:center; margin-top:10px">
+            填写 QQ 号后自动同步头像
+          </p>
         </div>
       </el-col>
     </el-row>
   </div>
 </template>
+
 <script>
 import axios from "axios";
-import { refreshUserInfo } from '@/assets/common'
+import { refreshUserInfo } from '@/assets/common';
 
 export default {
   name: "userProfile",
   data() {
-    return {
-      userInfo: {},
-      avatarAddress: '',
-    }
+    return { userInfo: {}, avatarAddress: '/default-avatar.svg' };
   },
   methods: {
     getAvatarAddress(qq) {
@@ -58,11 +67,8 @@ export default {
     },
     submit() {
       axios.post('/api/user/updateUserPublicInfo', { userInfo: this.userInfo }).then(res => {
-        if (res.status === 200) {
-          this.$message.success('更新成功');
-        } else {
-          this.$message.error('更新失败' + res.data.message);
-        }
+        if (res.status === 200) this.$message.success('更新成功');
+        else this.$message.error('更新失败 ' + res.data.message);
         refreshUserInfo();
         this.all();
       });
@@ -72,23 +78,50 @@ export default {
         this.userInfo = res.data.info;
         this.avatarAddress = this.getAvatarAddress(this.userInfo.qq);
       });
-    }
+    },
   },
-  mounted() {
-    this.all();
-  }
-}
+  watch: {
+    'userInfo.qq'(val) {
+      this.avatarAddress = this.getAvatarAddress(val);
+    },
+  },
+  mounted() { this.all(); },
+};
 </script>
 
 <style scoped>
-.header {
-  font-size: 24px;
+.profile-wrap { margin: 0 20px; padding-bottom: 24px; }
+
+.section-title {
+  font-size: 22px;
   font-weight: 800;
+  color: #2c3e50;
 }
 
+.profile-form { margin-top: 8px; }
+
 .attach {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
-  color: rgba(0, 0, 0, .4);
+  color: rgba(0,0,0,.4);
+  display: block;
+  margin-top: 4px;
+}
+
+.avatar-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 48px;
+}
+
+.avatar-img {
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+}
+
+@media (max-width: 576px) {
+  .profile-wrap { margin: 0 12px; }
+  .avatar-col { padding-top: 12px; }
 }
 </style>


### PR DESCRIPTION
## Summary
- 把 `/Users/ty/Downloads/pr/web/` 中由 Claude Design 重新设计的 8 个 Vue 文件迁移到当前前端，统一使用新的 `page-wrap` / `card-header` / `filter-bar` / `nav-desktop` + 移动抽屉布局。
- `App.vue` 改为统一的 sticky header + 全局 CSS 类系统；`myHeader.vue` 桌面 flex 导航 + 768px 以下汉堡抽屉；`indexPage.vue` 把原 `cuteRank` / `rabbitData` 子组件内联，并直接 `import echarts/core` 渲染点击数图。
- 保留所有鉴权和 API 行为：`$store.state.uid/gid/name/preferenceLang`、`/api/user/logout`、`gid === 3` / `gid >= 2` / `gid > 1` 守卫一致；`problemView.vue` 保留 `langList[submitLang]?.lang ?? 'cpp'` 可选链以避免初始 null 报错。

## Files
- `web/src/App.vue`
- `web/src/components/myHeader.vue`
- `web/src/components/indexPage.vue`
- `web/src/components/contest/contestList.vue`
- `web/src/components/problem/problemList.vue`
- `web/src/components/problem/problemView.vue`
- `web/src/components/submission/submissionList.vue`
- `web/src/components/user/edit/userProfile.vue`

## Notes for reviewer
- `web/src/components/rabbit/cuteRankList.vue` 与 `rabbitClickData.vue` 在迁移后已无引用，但本 PR 暂不删除，可单独再开 PR 清理。
- `echarts` 已是项目依赖（之前 `rabbitClickData.vue` 在用），未新增 npm 包。
- 仅 UI/样式/模板 + 局部脚本结构变化，无接口或后端依赖变更。

## Test plan
- [ ] `cd web && npm run serve`，桌面分辨率走一遍 `/`、`/problem`、`/contest`、`/submission`、`/problem/:pid`、`/user/edit`，确认布局、卡片头、过滤栏、表格列正确，无 console 错误
- [ ] 缩到 ≤768px：`myHeader` 切换汉堡抽屉，`hide-on-mobile` 列消失，`page-wrap` 边距收敛
- [ ] 鉴权流：未登录显示登录/注册；普通用户不见添加题目/比赛/公告与管理员入口；`gid === 3` 管理员见全部入口；点退出登录后状态清空并跳首页，移动抽屉同步关闭
- [ ] 题目页选择语言并提交一次代码，确认 `submitLang` 不出现 `Cannot read properties of null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)