### PR TITLE
chore: rip out gid authorization, drop the column

### DIFF
--- a/server/api/admin.js
+++ b/server/api/admin.js
@@ -1,8 +1,9 @@
 const db = require('../db');
-const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
+const { handler, fail, ok, paginate, buildWhere } = require('../db/util');
+const { requirePermission } = require('../auth/middleware');
 
 exports.getUserInfoList = [
-  requireRole(3),
+  requirePermission('user.list'),
   handler(async (req, res) => {
     const { offset, limit } = paginate(req);
     const filter = req.body.filter || {};
@@ -11,23 +12,47 @@ exports.getUserInfoList = [
       ['uid=?', filter.uid],
       ['name LIKE ?', filter.name ? `%${filter.name}%` : null],
       ['email LIKE ?', filter.email ? `%${filter.email}%` : null],
-      ['gid=?', filter.gid],
       // 前端 inUse=1 表示封禁(=0)，inUse=2 表示正常(=1)
       ['inUse=?', filter.inUse ? 2 - filter.inUse : null],
     ];
-    const { where, params } = buildWhere(cond, 'uid > 0');
+
+    // Filter by role: filter.roleKey is the role's `key` (e.g. 'moderator').
+    let join = '';
+    let extraParams = [];
+    if (filter.roleKey) {
+      join = ' INNER JOIN user_roles ur ON ur.uid = u.uid INNER JOIN roles r ON r.id = ur.role_id AND r.`key`=?';
+      extraParams.push(filter.roleKey);
+    }
+    const { where, params } = buildWhere(cond, 'u.uid > 0');
 
     const list = await db.query(
-      `SELECT uid,name,email,gid,inUse FROM userInfo${where} LIMIT ?,?`,
-      [...params, offset, limit]
+      `SELECT u.uid,u.name,u.email,u.inUse FROM userInfo u${join}${where} LIMIT ?,?`,
+      [...extraParams, ...params, offset, limit]
     );
-    const cnt = await db.one(`SELECT COUNT(*) as total FROM userInfo${where}`, params);
+    const cnt = await db.one(
+      `SELECT COUNT(*) as total FROM userInfo u${join}${where}`,
+      [...extraParams, ...params]
+    );
+    // Attach roles to each row so the admin table can render badges.
+    if (list.length) {
+      const uids = list.map((r) => r.uid);
+      const links = await db.query(
+        'SELECT ur.uid, r.`key` AS roleKey FROM user_roles ur JOIN roles r ON r.id = ur.role_id WHERE ur.uid IN (?)',
+        [uids]
+      );
+      const byUid = new Map();
+      for (const l of links) {
+        if (!byUid.has(l.uid)) byUid.set(l.uid, []);
+        byUid.get(l.uid).push(l.roleKey);
+      }
+      for (const r of list) r.roles = byUid.get(r.uid) || [];
+    }
     return ok(res, { total: cnt.total, userList: list });
   }),
 ];
 
 exports.setBlock = [
-  requireRole(3),
+  requirePermission('user.ban'),
   handler(async (req, res) => {
     const { uid, status } = req.body;
     if (uid == null || status == null) return fail(res, '请确认信息完善');
@@ -38,14 +63,14 @@ exports.setBlock = [
 ];
 
 exports.updateUserInfo = [
-  requireRole(3),
+  requirePermission('user.edit'),
   handler(async (req, res) => {
     const info = req.body.info || {};
-    const { uid, name, email, gid } = info;
-    if (!uid || !name || !gid) return fail(res, '请确认信息完善');
+    const { uid, name, email } = info;
+    if (!uid || !name) return fail(res, '请确认信息完善');
     const r = await db.query(
-      'UPDATE userInfo SET name=?,email=?,gid=? WHERE uid=?',
-      [name, email, gid, uid]
+      'UPDATE userInfo SET name=?,email=? WHERE uid=?',
+      [name, email, uid]
     );
     if (!r.affectedRows) return fail(res, 'failed');
     return ok(res);
@@ -53,7 +78,7 @@ exports.updateUserInfo = [
 ];
 
 exports.addAnnouncement = [
-  requireRole(3),
+  requirePermission('announcement.manage'),
   handler(async (req, res) => {
     const r = await db.query(
       'INSERT INTO announcement(title,description,weight,time) VALUES (?,?,?,?)',
@@ -65,7 +90,7 @@ exports.addAnnouncement = [
 ];
 
 exports.updateAnnouncement = [
-  requireRole(3),
+  requirePermission('announcement.manage'),
   handler(async (req, res) => {
     const info = req.body.info || {};
     const { aid, title, description, weight } = info;

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -114,7 +114,7 @@ exports.listUserGrants = handler(async (req, res) => {
   const uid = parseInt(req.body.uid, 10);
   if (!uid) return fail(res, '请确认信息完善');
 
-  const target = await db.one('SELECT uid, name, gid FROM userInfo WHERE uid=?', [uid]);
+  const target = await db.one('SELECT uid, name FROM userInfo WHERE uid=?', [uid]);
   if (!target) return fail(res, '用户不存在');
 
   const roles = await db.column(

--- a/server/api/common.js
+++ b/server/api/common.js
@@ -28,7 +28,7 @@ exports.getPaste = handler(async (req, res) => {
     [req.body.mark]
   );
   if (!row) return fail(res, '未找到');
-  if (req.session.gid < 3 && !row.isPublic && row.uid !== req.session.uid) {
+  if (!req.can('paste.edit.any') && !row.isPublic && row.uid !== req.session.uid) {
     return fail(res, '无权限查看');
   }
   row.time = Format(row.time);
@@ -55,7 +55,7 @@ exports.updatePaste = handler(async (req, res) => {
 
   const owner = await db.one('SELECT uid FROM pastes WHERE mark=?', [paste.mark]);
   if (!owner) return fail(res, '未找到');
-  if (req.session.gid < 3 && req.session.uid !== owner.uid) {
+  if (!req.can('paste.edit.any') && req.session.uid !== owner.uid) {
     return fail(res, '你只能修改自己的paste');
   }
 
@@ -71,7 +71,7 @@ exports.delPaste = handler(async (req, res) => {
   const { mark } = req.body;
   const owner = await db.one('SELECT uid FROM pastes WHERE mark=?', [mark]);
   if (!owner) return fail(res, '未找到');
-  if (req.session.gid < 3 && req.session.uid !== owner.uid) {
+  if (!req.can('paste.edit.any') && req.session.uid !== owner.uid) {
     return fail(res, '你只能删除自己的paste');
   }
   const result = await db.query('DELETE FROM pastes WHERE mark=?', [mark]);
@@ -82,7 +82,7 @@ exports.delPaste = handler(async (req, res) => {
 exports.getPasteList = handler(async (req, res) => {
   const { offset, limit } = paginate(req);
   let uid = req.body.uid || null;
-  if (req.session.gid < 3) uid = req.session.uid;
+  if (!req.can('paste.edit.any')) uid = req.session.uid;
 
   const cond = [['p.uid=?', uid]];
   const { where, params } = buildWhere(cond);

--- a/server/api/contest.js
+++ b/server/api/contest.js
@@ -1,5 +1,6 @@
 const db = require('../db');
-const { handler, fail, ok, requireRole, paginate } = require('../db/util');
+const { handler, fail, ok, paginate } = require('../db/util');
+const { requirePermission } = require('../auth/middleware');
 const { Format, briefFormat, kbFormat } = require('../static');
 const { judgeRes, formatSubmissionRow, formatCaseRow, ctype, cstatus } = require('../db/format');
 const { pushSidIntoQueue } = require('./judge');
@@ -9,6 +10,13 @@ const ctypeToIndex = { OI: 0, IOI: 1 };
 const ptype = ['传统文本比较', 'Special Judge'];
 
 // ---- shared helpers ----
+// Owner of a contest, OR holder of contest.edit.any (global or scoped to this cid).
+const canManageContest = (req, contest) => {
+  if (!contest) return false;
+  if (contest.host === req.session.uid) return true;
+  return req.can('contest.edit.any', { type: 'contest', id: Number(contest.cid) });
+};
+
 const contestStatus = (info) => {
   if (info.done) return 3;
   if (Date.now() > info.start.getTime() + info.length * 1000 * 60) return 2;
@@ -42,15 +50,17 @@ const loadContestForView = async (req, cid) => {
   const canView =
     (contest.status === 3 && (contest.isPublic || isReged)) ||
     (isReged && contest.status > 0) ||
-    req.session.gid >= 2;
+    canManageContest(req, contest);
   return { contest, status: contest.status, isReged, canView };
 };
 
+// During an OI contest in progress, regular contestants see scrubbed scores/results.
+// `manager` here means the user can manage the contest (owner / contest.edit.any).
 const formatContestSubmissionRow = async (r, ctx) => {
   r.idx = await getIdxByPid(ctx.cid, r.pid);
   r.pid = null;
   r.submitTime = Format(r.submitTime);
-  if (!ctx.contest.type && !ctx.contest.done && ctx.gid === 1) {
+  if (!ctx.contest.type && !ctx.contest.done && !ctx.manager) {
     r.score = r.judgeResult = r.time = r.memory = 0;
   }
   r.judgeResult = judgeRes[r.judgeResult];
@@ -60,7 +70,7 @@ const formatContestSubmissionRow = async (r, ctx) => {
 
 // ---- handlers ----
 exports.createContest = [
-  requireRole(2),
+  requirePermission('contest.create'),
   handler(async (req, res) => {
     const r = await db.query(
       'INSERT INTO contest(title,host,start,length,type,isPublic) VALUES (?,?,?,?,?,?)',
@@ -72,12 +82,11 @@ exports.createContest = [
 ];
 
 exports.updateContestInfo = [
-  requireRole(2),
   handler(async (req, res) => {
     const { cid, info } = req.body;
     const contest = await getContest(cid);
     if (!contest) return fail(res, '无此比赛');
-    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+    if (!canManageContest(req, contest))
       return fail(res, '你只能修改自己的比赛');
     if (contest.done) return fail(res, '比赛已经结束');
     if (!info.title || !info.start || !info.length || !info.type) return fail(res, '请确认信息完善');
@@ -122,7 +131,8 @@ exports.getContestInfo = handler(async (req, res) => {
   if (!contest) return fail(res, '无此比赛');
 
   contest.isReg = await isReg(req.session.uid, contest.cid);
-  if (!contest.isPublic && !contest.isReg && req.session.gid === 1)
+  const isManager = canManageContest(req, contest);
+  if (!contest.isPublic && !contest.isReg && !isManager)
     return fail(res, '比赛私有，请联系管理员报名');
 
   contest.playerCnt = await playerCnt(contest.cid);
@@ -131,11 +141,12 @@ exports.getContestInfo = handler(async (req, res) => {
   contest.end = Format(new Date(new Date(contest.start).getTime() + contest.length * 1000 * 60));
   contest.regAble = status < 2 && contest.isPublic && !contest.isReg;
   contest.auth = {
-    join: (contest.isReg && status > 0) || req.session.gid >= 2,
+    join: (contest.isReg && status > 0) || isManager,
     view:
       status === 3 ||
       (contest.isReg && contest.type === 1 && status > 0) ||
-      req.session.gid >= 2,
+      isManager,
+    manage: isManager,
   };
   contest.type = ctype[contest.type];
   contest.start = Format(contest.start);
@@ -143,34 +154,47 @@ exports.getContestInfo = handler(async (req, res) => {
   return ok(res, { data: contest });
 });
 
-exports.addPlayer = [
-  requireRole(2),
-  handler(async (req, res) => {
-    const { cid, name } = req.body;
-    const user = await db.one('SELECT uid FROM userInfo WHERE name=? LIMIT 1', [name]);
-    if (!user) return fail(res, '无此用户');
+// Owner / contest.player.manage / contest.edit.any (scoped or global) can manage players.
+const canManagePlayers = async (req, cid) => {
+  const contest = await getContest(cid);
+  if (!contest) return null;
+  const scope = { type: 'contest', id: Number(cid) };
+  if (canManageContest(req, contest)) return contest;
+  if (req.can('contest.player.manage', scope)) return contest;
+  return false;
+};
 
-    const already = await db.exists(
-      'SELECT 1 FROM contestPlayer WHERE cid=? AND uid=?',
-      [cid, user.uid]
-    );
-    if (already) return fail(res, '此用户已被添加入比赛');
+exports.addPlayer = handler(async (req, res) => {
+  const { cid, name } = req.body;
+  const allowed = await canManagePlayers(req, cid);
+  if (allowed === null) return fail(res, '无此比赛');
+  if (!allowed) return res.status(403).end('403 Forbidden');
 
-    await db.query('INSERT INTO contestPlayer(cid,uid) VALUES (?,?)', [cid, user.uid]);
-    return ok(res);
-  }),
-];
+  const user = await db.one('SELECT uid FROM userInfo WHERE name=? LIMIT 1', [name]);
+  if (!user) return fail(res, '无此用户');
 
-exports.removePlayer = [
-  requireRole(2),
-  handler(async (req, res) => {
-    const ids = (req.body.list || []).map((x) => x.id);
-    if (!ids.length) return ok(res);
-    const r = await db.query('DELETE FROM contestPlayer WHERE id in(?)', [ids]);
-    if (!r.affectedRows) return fail(res, 'error');
-    return ok(res);
-  }),
-];
+  const already = await db.exists(
+    'SELECT 1 FROM contestPlayer WHERE cid=? AND uid=?',
+    [cid, user.uid]
+  );
+  if (already) return fail(res, '此用户已被添加入比赛');
+
+  await db.query('INSERT INTO contestPlayer(cid,uid) VALUES (?,?)', [cid, user.uid]);
+  return ok(res);
+});
+
+exports.removePlayer = handler(async (req, res) => {
+  const { cid } = req.body;
+  const allowed = await canManagePlayers(req, cid);
+  if (allowed === null) return fail(res, '无此比赛');
+  if (!allowed) return res.status(403).end('403 Forbidden');
+
+  const ids = (req.body.list || []).map((x) => x.id);
+  if (!ids.length) return ok(res);
+  const r = await db.query('DELETE FROM contestPlayer WHERE id in(?) AND cid=?', [ids, cid]);
+  if (!r.affectedRows) return fail(res, 'error');
+  return ok(res);
+});
 
 exports.getPlayerList = handler(async (req, res) => {
   const { offset, limit } = paginate(req);
@@ -184,12 +208,11 @@ exports.getPlayerList = handler(async (req, res) => {
 });
 
 exports.closeContest = [
-  requireRole(2),
   handler(async (req, res) => {
     const { cid } = req.body;
     const contest = await getContest(cid);
     if (!contest) return fail(res, '无此比赛');
-    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+    if (!canManageContest(req, contest))
       return fail(res, '你只能修改自己的比赛');
     const status = contestStatus(contest);
     if (status < 2) return fail(res, '还未至比赛截止时间');
@@ -220,7 +243,7 @@ exports.getPlayerProblemList = handler(async (req, res) => {
   const reged = await isReg(req.session.uid, contest.cid);
   const status = contestStatus(contest);
   const allowed =
-    (reged && status > 0) || req.session.gid >= 2 || ((contest.isPublic || reged) && contest.done);
+    (reged && status > 0) || canManageContest(req, contest) || ((contest.isPublic || reged) && contest.done);
   if (!allowed) return res.status(403).end('403 Forbidden');
 
   const data = await db.query(
@@ -237,9 +260,10 @@ exports.getProblemInfo = handler(async (req, res) => {
   const v = await loadContestForView(req, cid);
   if (!v) return fail(res, '无此比赛');
   // 这里使用比赛进入条件，不是 view-only
+  const isManager = canManageContest(req, v.contest);
   const allowed =
     (v.isReged && v.status > 0) ||
-    req.session.gid >= 2 ||
+    isManager ||
     ((v.contest.isPublic || v.isReged) && v.contest.done);
   if (!allowed) return res.status(403).end('403 Forbidden');
 
@@ -253,7 +277,7 @@ exports.getProblemInfo = handler(async (req, res) => {
   );
   if (!problem) return fail(res, '无此题目');
 
-  if (req.session.gid >= 2) problem.pid = pinfo.pid;
+  if (isManager) problem.pid = pinfo.pid;
   problem.lang = (await getProblemLang(pinfo.pid)) & v.contest.lang;
   problem.type = ptype[problem.type];
   problem.time = briefFormat(problem.time);
@@ -263,11 +287,11 @@ exports.getProblemInfo = handler(async (req, res) => {
 });
 
 exports.getProblemList = [
-  requireRole(2),
   handler(async (req, res) => {
     const { cid } = req.body;
     const contest = await getContest(cid);
     if (!contest) return fail(res, '无此比赛');
+    if (!canManageContest(req, contest)) return res.status(403).end('403 Forbidden');
 
     const data = await db.query(
       'SELECT cp.idx,cp.pid,p.title,p.time,cp.weight,p.isPublic,p.publisher as publisherUid,u.name as publisher ' +
@@ -281,7 +305,6 @@ exports.getProblemList = [
 ];
 
 exports.updateProblemList = [
-  requireRole(2),
   handler(async (req, res) => {
     const { cid, list } = req.body;
     const seen = {};
@@ -298,7 +321,7 @@ exports.updateProblemList = [
     }
     const contest = await getContest(cid);
     if (!contest) return fail(res, '无此比赛');
-    if (req.session.uid !== 1 && contest.host !== req.session.uid)
+    if (!canManageContest(req, contest))
       return fail(res, '你只能修改自己的比赛');
     if (contestStatus(contest) === 3) return fail(res, '比赛已结束');
 
@@ -377,7 +400,7 @@ exports.getSubmissionList = handler(async (req, res) => {
       `WHERE cid=?${extra} ORDER BY s.sid DESC LIMIT ?,?`,
     [...params, offset, limit]
   );
-  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  const ctx = { cid, contest: v.contest, manager: canManageContest(req, v.contest) };
   for (const r of list) await formatContestSubmissionRow(r, ctx);
 
   const cnt = await db.one(
@@ -403,7 +426,7 @@ exports.getLastSubmissionList = handler(async (req, res) => {
       'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.sid in (?)',
     [sids]
   );
-  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  const ctx = { cid, contest: v.contest, manager: canManageContest(req, v.contest) };
   for (const r of list) await formatContestSubmissionRow(r, ctx);
   return ok(res, { data: list, total: allLast.length });
 });
@@ -421,10 +444,12 @@ exports.getSubmissionInfo = handler(async (req, res) => {
   if (!contest) return fail(res, '无此比赛');
   contest.status = contestStatus(contest);
   const reged = await isReg(req.session.uid, row.cid);
+  const isManager = canManageContest(req, contest);
   const allowed =
     (contest.status === 3 && (contest.isPublic || reged)) ||
     req.session.uid === row.uid ||
-    req.session.gid > 1;
+    isManager ||
+    req.can('submission.view.any');
   if (!allowed) return res.status(403).end('403 Forbidden');
 
   row.caseResult = JSON.parse(row.caseResult);
@@ -432,7 +457,7 @@ exports.getSubmissionInfo = handler(async (req, res) => {
   row.singleCaseResult.sort((a, b) => a.caseId - b.caseId);
   row.done = false;
 
-  const fullView = req.session.gid > 1 || contest.status === 3;
+  const fullView = isManager || req.can('submission.view.any') || contest.status === 3;
 
   if (row.caseResult) {
     const subtaskInfo = {};
@@ -463,8 +488,8 @@ exports.getSubmissionInfo = handler(async (req, res) => {
       formatCaseRow(c);
     }
   }
-  // OI 赛制比赛中：选手只能看到提交时间，不能看到结果
-  if (!contest.type && !contest.done && req.session.gid === 1) {
+  // OI 赛制比赛中：非管理员选手只能看到提交时间，不能看到结果
+  if (!contest.type && !contest.done && !isManager) {
     row.caseResult = row.singleCaseResult = row.subtaskInfo = null;
     row.score = row.judgeResult = row.time = row.memory = 0;
     row.unShown = true;
@@ -490,7 +515,7 @@ exports.getRank = handler(async (req, res) => {
   const allowed =
     (status === 3 && (contest.isPublic || reged)) ||
     (reged && contest.type === 1 && status > 0) ||
-    req.session.gid >= 2;
+    canManageContest(req, contest);
   if (!allowed) return res.status(403).end('403 Forbidden');
 
   const pidToIdx = [];
@@ -564,7 +589,7 @@ exports.getSingleUserLastSubmission = handler(async (req, res) => {
       'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid WHERE s.sid in (?)',
     [sids]
   );
-  const ctx = { cid, contest: v.contest, gid: req.session.gid };
+  const ctx = { cid, contest: v.contest, manager: canManageContest(req, v.contest) };
   for (const r of list) await formatContestSubmissionRow(r, ctx);
   return ok(res, { data: list });
 });
@@ -584,11 +609,12 @@ exports.getSingleUserProblemSubmission = handler(async (req, res) => {
       'WHERE s.cid=? AND s.uid=? AND s.pid=? ORDER BY s.sid DESC',
     [cid, uid, pinfo.pid]
   );
+  const isManager = canManageContest(req, v.contest);
   for (const r of list) {
     r.idx = idx;
     r.pid = null;
     r.submitTime = Format(r.submitTime);
-    if (!v.contest.type && !v.contest.done && req.session.gid === 1) {
+    if (!v.contest.type && !v.contest.done && !isManager) {
       r.score = r.judgeResult = r.time = r.memory = 0;
     }
     r.judgeResult = judgeRes[r.judgeResult];

--- a/server/api/fileUpload.js
+++ b/server/api/fileUpload.js
@@ -8,10 +8,10 @@ const { problemAuth } = require('./problem');
 
 const CASE_MAX_TOTAL_SIZE = 200 * 1024 * 1024; // 200MB limit
 
-// Check zip file size before extraction
-const checkZipSize = (zipPath, userGid, maxTotalSize) => {
+// Check zip file size before extraction. `unlimited=true` skips the cap (super-admin equivalent).
+const checkZipSize = (zipPath, unlimited, maxTotalSize) => {
   return new Promise((resolve, reject) => {
-    if (userGid >= 3) {
+    if (unlimited) {
       resolve(true);
       return;
     }
@@ -90,11 +90,11 @@ const processUploadedFiles = async (files, destination) => {
 
 const handleCaseUpload = async (req, res) => {
   try {
-    if (req.session.gid < 2 || !((await problemAuth(req, req.body.pid)).manage)) {
+    if (!(await problemAuth(req, req.body.pid)).manage) {
       return res.status(403).end('403 Forbidden');
     }
 
-    const isSizeValid = await checkZipSize(req.file.path, req.session.gid, CASE_MAX_TOTAL_SIZE);
+    const isSizeValid = await checkZipSize(req.file.path, req.can('problem.edit.any'), CASE_MAX_TOTAL_SIZE);
     if (!isSizeValid) {
       fs.unlinkSync(req.file.path); // delete
       return res.status(202).send({

--- a/server/api/judge.js
+++ b/server/api/judge.js
@@ -3,7 +3,8 @@ const async = require('async');
 const { exec } = require('child_process');
 const { fork } = require('child_process');
 const db = require('../db');
-const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
+const { handler, fail, ok, paginate, buildWhere } = require('../db/util');
+const { requirePermission } = require('../auth/middleware');
 const { Format, kbFormat } = require('../static');
 const conf = require('../config.json');
 const { updateProblemStat, problemAuth, getProblemLang } = require('./problem');
@@ -136,10 +137,10 @@ exports.submit = handler(async (req, res) => {
 
 exports.getSubmissionList = handler(async (req, res) => {
   const { offset, limit } = paginate(req);
-  const visibility = req.session.gid < 2 ? 'p.isPublic=1' : 'p.isPublic<6';
+  const visibility = req.can('submission.view.any') ? 'p.isPublic<6' : 'p.isPublic=1';
 
-  // 只有 queryAll && gid!=1 才能跨比赛查询；否则强制 cid=0
-  const restrictToNoContest = !req.body.queryAll || req.session.gid === 1;
+  // Only callers with cross-contest visibility can pass cid via queryAll; others are forced to cid=0.
+  const restrictToNoContest = !req.body.queryAll || !req.can('contest.submission.view.cross');
   const cond = [
     restrictToNoContest ? ['s.cid=0'] : ['s.cid=?', req.body.cid],
     ['u.name=?', req.body.name],
@@ -168,7 +169,7 @@ exports.getSubmissionList = handler(async (req, res) => {
 
 exports.getSubmissionInfo = handler(async (req, res) => {
   const { sid } = req.body;
-  const visibility = req.session.gid < 2 ? ' AND p.isPublic=1' : '';
+  const visibility = req.can('submission.view.any') ? '' : ' AND p.isPublic=1';
   const row = await db.one(
     'SELECT s.sid,s.uid,s.pid,s.judgeResult,s.time,s.memory,s.score,s.code,s.codeLength,s.submitTime,s.compileResult,s.caseResult,s.machine,s.lang,u.name,p.title,p.isPublic ' +
       'FROM submission s INNER JOIN userInfo u ON u.uid = s.uid INNER JOIN problem p ON p.pid=s.pid ' +
@@ -206,7 +207,7 @@ exports.getSubmissionInfo = handler(async (req, res) => {
 });
 
 exports.reJudge = [
-  requireRole(2),
+  requirePermission('submission.rejudge'),
   handler(async (req, res) => {
     await exports.setSubmission(req.body.sid, 2, 0, 0, 0, null, null);
     pushSidIntoQueue(req.body.sid, true);
@@ -216,9 +217,11 @@ exports.reJudge = [
 ];
 
 exports.reJudgeProblem = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid } = req.body;
+    const scope = { type: 'problem', id: Number(pid) };
+    if (!req.can('submission.rejudge', scope) && !(await problemAuth(req, pid)).manage)
+      return res.status(403).end('403 Forbidden');
     const list = await db.query('SELECT sid FROM submission WHERE pid=?', [pid]);
     for (const s of list) {
       exports.setSubmission(s.sid, 2, 0, 0, 0, null, null);
@@ -231,9 +234,15 @@ exports.reJudgeProblem = [
 ];
 
 exports.reJudgeContest = [
-  requireRole(2),
   handler(async (req, res) => {
-    const list = await db.query('SELECT sid FROM submission WHERE cid=?', [req.body.cid]);
+    const cid = req.body.cid;
+    const scope = { type: 'contest', id: Number(cid) };
+    if (!req.can('submission.rejudge', scope)) {
+      const c = await db.one('SELECT host FROM contest WHERE cid=?', [cid]);
+      if (!c || (c.host !== req.session.uid && !req.can('contest.edit.any', scope)))
+        return res.status(403).end('403 Forbidden');
+    }
+    const list = await db.query('SELECT sid FROM submission WHERE cid=?', [cid]);
     for (const s of list) {
       await exports.setSubmission(s.sid, 2, 0, 0, 0, null, null);
       pushSidIntoQueue(s.sid, true);
@@ -243,7 +252,7 @@ exports.reJudgeContest = [
 ];
 
 exports.cancelSubmission = [
-  requireRole(3),
+  requirePermission('submission.rejudge'),
   handler(async (req, res) => {
     const { sid } = req.body;
     await db.query('UPDATE submission SET judgeResult=13,score=0 WHERE sid=?', [sid]);

--- a/server/api/problem.js
+++ b/server/api/problem.js
@@ -2,7 +2,8 @@ require('express-zip');
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
-const { handler, fail, ok, requireRole, paginate, buildWhere } = require('../db/util');
+const { handler, fail, ok, paginate, buildWhere } = require('../db/util');
+const { requirePermission } = require('../auth/middleware');
 const { getFile, setFile } = require('../file');
 const { briefFormat, Format, bFormat, recordEvent, kbFormat } = require('../static');
 const { judgeRes, ptype } = require('../db/format');
@@ -11,9 +12,11 @@ const { judgeRes, ptype } = require('../db/format');
 const problemAuth = async (req, pid) => {
   const row = await db.one('SELECT isPublic,publisher FROM problem WHERE pid=?', [pid]);
   if (!row) return { view: false, manage: false };
+  const scope = { type: 'problem', id: Number(pid) };
+  const isOwner = row.publisher === req.session.uid;
   return {
-    view: !!row.isPublic || req.session.gid > 1,
-    manage: row.publisher === req.session.uid || req.session.uid === 1,
+    view: !!row.isPublic || isOwner || req.can('problem.view.private'),
+    manage: isOwner || req.can('problem.edit.any', scope) || req.can('problem.case.manage', scope),
   };
 };
 exports.problemAuth = problemAuth;
@@ -37,7 +40,7 @@ exports.updateProblemStat = updateProblemStat;
 
 // ---- handlers ----
 exports.createProblem = [
-  requireRole(2),
+  requirePermission('problem.create'),
   handler(async (req, res) => {
     const r = await db.query(
       'INSERT INTO problem(title,description,publisher,time,tags) VALUES (?,?,?,?,?)',
@@ -49,7 +52,6 @@ exports.createProblem = [
 ];
 
 exports.updateProblem = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid } = req.body;
     const info = req.body.info || {};
@@ -57,7 +59,8 @@ exports.updateProblem = [
     if (!info.title || !info.description || !info.timeLimit || !info.memoryLimit || !pid)
       return fail(res, '请确认信息完善');
 
-    if (req.session.gid < 3) {
+    // Holders of global problem.edit.any (e.g. moderator+) bypass per-problem limits.
+    if (!req.can('problem.edit.any')) {
       if (info.timeLimit > 10000 || info.timeLimit < 0) return fail(res, '时间限制最大为10000ms');
       if (info.memoryLimit > 512 || info.memoryLimit < 0) return fail(res, '空间限制最大为512MB');
       if (info.tags?.length > 5) return fail(res, '题目标签最多设置5个');
@@ -86,7 +89,7 @@ exports.getProblemList = handler(async (req, res) => {
   const filter = req.body.filter || {};
   if (filter.level === 6) filter.level = null;
 
-  const visibility = req.session.gid > 1 ? '1=1' : 'isPublic=1';
+  const visibility = req.can('problem.view.private') ? '1=1' : 'isPublic=1';
   const tagsParam = filter.tags?.length ? JSON.stringify(filter.tags) : null;
 
   // 注意：原实现里 list 用 (title LIKE ? OR description LIKE ?)，而 count 只看 title — 这里统一用同一份条件以避免漂移
@@ -115,7 +118,7 @@ exports.getProblemList = handler(async (req, res) => {
 
 exports.getProblemInfo = handler(async (req, res) => {
   const { pid } = req.body;
-  const visibility = req.session.gid > 1 ? '' : ' AND isPublic=1';
+  const visibility = req.can('problem.view.private') ? '' : ' AND isPublic=1';
   const row = await db.one(
     'SELECT p.pid,p.title,p.acCnt,p.submitCnt,p.description,p.time,p.timeLimit,p.memoryLimit,p.isPublic,p.type,p.tags,p.level,p.lang,p.publisher as publisherUid,u.`name` as publisher ' +
       'FROM problem p INNER JOIN userInfo u ON u.uid = p.publisher WHERE pid=?' + visibility,
@@ -129,9 +132,9 @@ exports.getProblemInfo = handler(async (req, res) => {
 });
 
 exports.getProblemCasePreview = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid } = req.body;
+    if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
     const cfgRaw = await getFile(`./data/${pid}/config.json`);
     const data = cfgRaw ? JSON.parse(cfgRaw) : null;
 
@@ -178,7 +181,6 @@ exports.getProblemCasePreview = [
 ];
 
 exports.clearCase = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid } = req.body;
     if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
@@ -190,7 +192,6 @@ exports.clearCase = [
 ];
 
 exports.updateSubtaskId = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid, cases, subtask } = req.body;
     if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
@@ -248,7 +249,6 @@ exports.updateSubtaskId = [
 ];
 
 exports.getCase = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid, caseInfo } = req.body;
     if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
@@ -265,7 +265,6 @@ exports.getCase = [
 ];
 
 exports.updateCase = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid, caseInfo } = req.body;
     if (!(await problemAuth(req, pid)).manage) return res.status(403).end('403 Forbidden');
@@ -287,13 +286,15 @@ exports.updateCase = [
 ];
 
 exports.downloadCase = [
-  requireRole(2),
   handler(async (req, res) => {
     const { pid, index } = req.query;
     const problem = await db.one('SELECT publisher FROM problem WHERE pid=?', [pid]);
     if (!problem || !fs.existsSync(`./data/${pid}/config.json`)) return fail(res, 'Not Found Error');
-    if (req.session.uid !== 1 && problem.publisher !== req.session.uid)
-      return fail(res, '你只能下载自己题目的测试点');
+    const scope = { type: 'problem', id: Number(pid) };
+    const allowed = problem.publisher === req.session.uid
+      || req.can('problem.case.manage', scope)
+      || req.can('problem.edit.any', scope);
+    if (!allowed) return fail(res, '你只能下载自己题目的测试点');
 
     const { cases } = JSON.parse(await getFile(`./data/${pid}/config.json`));
     const files = [];
@@ -361,7 +362,7 @@ exports.getProblemFastestSubmission = handler(async (req, res) => {
 exports.bindPaste2Problem = handler(async (req, res) => {
   const { pid, mark } = req.body;
   if (!pid || !mark) return fail(res, 'expect pid && mark');
-  if (req.session.gid < 2) return fail(res, '权限不足');
+  if (!(await problemAuth(req, pid)).manage) return fail(res, '权限不足');
 
   const exists = await db.exists('SELECT 1 FROM pastes WHERE mark=?', [mark]);
   if (!exists) return fail(res, `未找到mark为${mark}的剪贴板`);
@@ -386,7 +387,9 @@ exports.getProblemSol = handler(async (req, res) => {
 
 exports.unbindSol = handler(async (req, res) => {
   const { id } = req.body;
-  if (req.session.gid < 2) return fail(res, '权限不足');
+  const sol = await db.one('SELECT pid FROM problemSolution WHERE id=?', [id]);
+  if (!sol) return fail(res, '记录不存在');
+  if (!(await problemAuth(req, sol.pid)).manage) return fail(res, '权限不足');
   await db.query('UPDATE problemSolution SET `show`=0 WHERE id=?', [id]);
   return ok(res);
 });

--- a/server/api/rabbit.js
+++ b/server/api/rabbit.js
@@ -6,7 +6,9 @@ let dayClick = {};
 
 exports.all = handler(async (req, res) => {
   const list = await db.query(
-    'SELECT clickList.id,clickList.time,clickList.uid,userInfo.name,clickList.ip,clickList.iploc,userInfo.clickCnt,userInfo.gid ' +
+    'SELECT clickList.id,clickList.time,clickList.uid,userInfo.name,clickList.ip,clickList.iploc,userInfo.clickCnt, ' +
+      '(SELECT 1 FROM user_roles ur JOIN roles r ON r.id=ur.role_id ' +
+      "WHERE ur.uid=userInfo.uid AND r.`key` IN ('moderator','super_admin') LIMIT 1) AS isStaff " +
       'FROM clickList INNER JOIN userInfo ON userInfo.uid = clickList.uid ' +
       'ORDER BY clickList.id DESC LIMIT 20'
   );
@@ -50,7 +52,10 @@ exports.getClickCnt = handler(async (req, res) => {
 exports.getRankInfo = handler(async (req, res) => {
   const { pageId, offset, limit } = paginate(req);
   const list = await db.query(
-    'SELECT uid,name,clickCnt,motto,gid,qq FROM userInfo GROUP BY uid ORDER BY clickCnt DESC LIMIT ?,?',
+    'SELECT u.uid,u.name,u.clickCnt,u.motto,u.qq, ' +
+      '(SELECT 1 FROM user_roles ur JOIN roles r ON r.id=ur.role_id ' +
+      "WHERE ur.uid=u.uid AND r.`key` IN ('moderator','super_admin') LIMIT 1) AS isStaff " +
+      'FROM userInfo u GROUP BY u.uid ORDER BY u.clickCnt DESC LIMIT ?,?',
     [offset, limit]
   );
   for (let i = 0; i < list.length; i++) {

--- a/server/api/user.js
+++ b/server/api/user.js
@@ -63,7 +63,6 @@ exports.login = handler(async (req, res) => {
   req.session.uid = user.uid;
   req.session.name = user.name;
   req.session.email = user.email;
-  req.session.gid = user.gid;
   recordEvent(req, 'user.login');
 
   const now = new Date();
@@ -94,7 +93,6 @@ exports.getUserInfo = handler(async (req, res) => {
   }
   req.session.name = user.name;
   req.session.email = user.email;
-  req.session.gid = user.gid;
   req.session.avatar = user.qq
     ? `https://q1.qlogo.cn/g?b=qq&nk=${user.qq}&s=3`
     : '/default-avatar.svg';
@@ -105,7 +103,6 @@ exports.getUserInfo = handler(async (req, res) => {
     name: req.session.name,
     email: req.session.email,
     ip: req.session.ip,
-    gid: req.session.gid,
     avatar: req.session.avatar,
     preferenceLang: req.session.preferenceLang,
     permissions,
@@ -198,13 +195,19 @@ exports.setUserEmail = handler(async (req, res) => {
 exports.getUserPublicInfo = handler(async (req, res) => {
   const { uid } = req.body;
   const info = await db.one(
-    'SELECT uid,name,email,reg_time,login_time,clickCnt,inUse,gid,motto,qq,preferenceLang FROM userInfo WHERE uid=?',
+    'SELECT uid,name,email,reg_time,login_time,clickCnt,inUse,motto,qq,preferenceLang FROM userInfo WHERE uid=?',
     [uid]
   );
   if (!info) return fail(res, '无此用户');
   if (info.reg_time) info.reg_time = briefFormat(info.reg_time);
   if (info.login_time) info.login_time = briefFormat(info.login_time);
-  if (req.session.gid !== 3 && req.session.uid !== info.uid) {
+  // Roles attached so the profile page can decorate the user (badges, name color).
+  info.roles = await db.column(
+    'SELECT r.`key` AS k FROM user_roles ur JOIN roles r ON r.id = ur.role_id WHERE ur.uid=?',
+    [uid],
+    'k'
+  );
+  if (!req.can('user.list') && req.session.uid !== info.uid) {
     delete info.login_time;
     delete info.email;
   }

--- a/server/app.js
+++ b/server/app.js
@@ -51,11 +51,9 @@ app.use((req, res, next) => {
   req.useragent = parser(req.headers['user-agent']);
   if (req.session.uid) {
     db.query('UPDATE userSession SET lastact=? WHERE token=? AND uid=?', [new Date(), req.sessionID, req.session.uid]).catch((err) => console.log(err));
-    if (req.url.match('^\/api\/admin') && !req.can('user.list'))
-      return res.status(403).end('403 Forbidden');
+    // Each /api/admin/* handler enforces its own fine-grained permission via requirePermission.
     next();
   } else {
-    req.session.gid = 1;
     if (req.url === '/api/user/login' ||
       req.url === '/api/user/reg' ||
       req.url === '/api/user/setUserEmail' ||

--- a/server/auth/MIGRATION.md
+++ b/server/auth/MIGRATION.md
@@ -1,0 +1,166 @@
+# 权限系统迁移指南：从 `gid` 到 RBAC
+
+本文说明如何把现有线上数据库 / 服务平滑迁移到新的权限系统。改动一次性完成，但部署节奏可控；本文给出一个保守的、零停机的步骤，也给出"直接切"的快速版本。
+
+## 改了什么
+
+- **数据库**：新增 `permissions` / `roles` / `role_permissions` / `user_roles` / `user_permissions` 5 张表；启动时 `CREATE TABLE IF NOT EXISTS` 自动创建。`userInfo.gid` 列在备份角色后被自动**删除**。
+- **服务端**：所有 `requireRole(N)` 和 `req.session.gid` 检查全部替换为 `requirePermission(key)` / `req.can(key, scope?)`；`req.session.gid` / `getUserInfo` 响应中的 `gid` 字段不再存在。
+- **前端**：所有 `store.state.gid` / `this.gid` 引用全部改为 `$can(key)` / `$canAny(...)`；store 不再保存 `gid`；`/admin/usermanage` 显示角色标签而非 `gid` 数字；新增 `/admin/permissions` 管理中心；题目和比赛页内嵌「协作者」面板。
+
+迁移本身**幂等**：服务启动时若 `userInfo.gid` 仍存在，先按现有 gid 把内置角色 (`user` / `moderator` / `super_admin`) 写入 `user_roles`，然后 `ALTER TABLE userInfo DROP COLUMN gid`；后续重启检测到列已不在则直接跳过。
+
+---
+
+## 推荐部署流程（建议）
+
+### 0. 先备份
+
+```bash
+mysqldump -u<user> -p<pass> <db> userInfo user_roles > backup-$(date +%Y%m%d).sql
+```
+
+注意备份 `userInfo`（含 gid）和已有的 `user_roles`（如果之前 PR1 已合并）。
+
+### 1. 在 staging 跑一次
+
+把同样代码部到一台 staging（或本地从生产拉一份 dump）：
+
+1. `npm install`（无新依赖，可跳）
+2. 启动服务，看日志：
+   - 第一次启动会打印 `[auth] dropping legacy userInfo.gid column`
+   - 此前若 `user_roles` 是空的，启动会先按 `gid` 回填，然后才删列
+3. 跑一遍验证：`node server/auth/test.js` 应输出 `71 passed, 0 failed`
+4. 浏览器验证关键链路：
+   - 登录 → 导航栏只对 `user.list` 角色显示「用户管理」
+   - `/admin/permissions` 三个 Tab 正常
+   - 普通用户能编辑自己的题目；moderator 能编辑别人的；super admin 能改任意
+
+### 2. 如果担心一次性切换，可以分两步
+
+代码层无法分两步；DB 层可以**先延迟删列**：
+
+```bash
+# 启动服务时禁用 ALTER：
+DISABLE_DROP_GID=1 node server/app.js
+```
+
+`sync.js` 会跳过 `ALTER TABLE userInfo DROP COLUMN gid`，其它一切照常工作。验证一段时间（24~48h）确认线上稳定后，去掉环境变量重启即可完成 drop。
+
+> ⚠️ **注意**：即便保留 `gid` 列，应用也已不读它。你看到的列只是历史数据，新增 / 修改用户都不会再写它。
+
+### 3. 真正部署到生产
+
+```bash
+# pull 新代码
+git pull origin main
+
+# （可选）首次切换时保留 gid 列做观察
+DISABLE_DROP_GID=1 pm2 restart nywoj   # 或你的进程管理器
+
+# 1~2 天后正式 drop：
+unset DISABLE_DROP_GID
+pm2 restart nywoj
+```
+
+第一次启动时日志一定会出现：
+
+```
+[auth] dropping legacy userInfo.gid column
+```
+
+如果没看到，说明 `gid` 列已经不存在了（可能上次启动已删），属于正常。
+
+### 4. 切完之后的验收
+
+```sql
+-- gid 列应已不存在
+DESCRIBE userInfo;
+
+-- 现有 gid=2 用户应都拿到了 moderator 角色
+SELECT u.uid, u.name, GROUP_CONCAT(r.`key`) AS roles
+FROM userInfo u
+LEFT JOIN user_roles ur ON ur.uid = u.uid
+LEFT JOIN roles r ON r.id = ur.role_id
+GROUP BY u.uid, u.name
+LIMIT 20;
+
+-- 检查是否有"光杆"用户（既没有任何角色，也没有任何 user_permissions），通常是新注册
+SELECT COUNT(*) FROM userInfo u
+WHERE NOT EXISTS (SELECT 1 FROM user_roles WHERE uid = u.uid)
+  AND NOT EXISTS (SELECT 1 FROM user_permissions WHERE uid = u.uid);
+```
+
+---
+
+## 快速版（线上能停几分钟）
+
+```bash
+# 1. 备份
+mysqldump <db> > backup.sql
+
+# 2. 部署
+git pull && pm2 restart nywoj
+
+# 3. 看日志确认 sync 跑完 + 列已删
+
+# 4. 验证关键页面
+```
+
+启动时间通常 < 5 秒，外加一次 `ALTER TABLE userInfo DROP COLUMN gid`（对一两万用户的表来说也是秒级）。
+
+---
+
+## 回滚
+
+如果上线后发现严重问题，回滚代码即可：
+
+```bash
+git revert <commit>
+pm2 restart nywoj
+```
+
+但有两个细节：
+
+1. **`gid` 列已被删除**。回滚后老代码尝试 `SELECT gid FROM userInfo` 会报错。需要先恢复列：
+   ```sql
+   ALTER TABLE userInfo ADD COLUMN gid INT NOT NULL DEFAULT 1;
+   -- 把现有 user_roles 反向回填到 gid（可选，用于让老代码看到「正确」的角色级别）：
+   UPDATE userInfo u SET gid = COALESCE(
+     (SELECT MAX(r.legacy_gid) FROM user_roles ur
+      JOIN roles r ON r.id = ur.role_id
+      WHERE ur.uid = u.uid AND r.legacy_gid IS NOT NULL),
+     1
+   );
+   ```
+2. 新表 (`permissions` / `roles` / `role_permissions` / `user_roles` / `user_permissions`) 留着无害，老代码不会读，可以保留以便重新升级时继续使用（数据不会丢）。
+
+为了规避「列被删 → 回滚困难」，**一定先用 `DISABLE_DROP_GID=1` 跑一段时间**再正式 drop。
+
+---
+
+## 上线后给用户分配角色
+
+旧用户已通过 gid 自动映射：
+- gid 1 → 无角色（普通用户）
+- gid 2 → `moderator` 角色（出题 + 办赛 + 重测三合一）
+- gid 3 → `super_admin` 角色（所有权限）
+
+新用户注册默认无角色。super admin 可在 `/admin/permissions` 的「用户授权」Tab 给用户分配角色，或在题目/比赛编辑页直接添加协作者。
+
+如果希望细分权限（比如只让 X 出题、只让 Y 办赛），把 X 的角色从 `moderator` 改为 `problem_setter`，把 Y 的角色改为 `contest_manager`，权限会自动收紧。
+
+---
+
+## 部署 checklist
+
+- [ ] 数据库备份
+- [ ] 代码拉到目标分支
+- [ ] `npm install` 无新依赖（可跳）
+- [ ] （可选）首次部署带 `DISABLE_DROP_GID=1`
+- [ ] 启动服务，日志看到 `[auth] dropping legacy userInfo.gid column`（或之前已删，无此日志）
+- [ ] `node server/auth/test.js` → 71 passed
+- [ ] 浏览器：以 super admin 身份验证 `/admin/permissions` 可访问
+- [ ] 浏览器：以普通用户身份验证编辑自己的题目能保存
+- [ ] 浏览器：以 moderator 身份验证创建题目 / 比赛 / 重测正常
+- [ ] 24~48h 观察期后 `unset DISABLE_DROP_GID && restart`，确认 `gid` 列被删除

--- a/server/auth/sync.js
+++ b/server/auth/sync.js
@@ -101,9 +101,22 @@ const syncBuiltinRoles = async () => {
   }
 };
 
+// Returns true if the column exists. Used to gate the gid → role backfill so we
+// can run sync repeatedly even after the legacy column has been dropped.
+const columnExists = async (table, column) => {
+  const row = await db.one(
+    `SELECT 1 FROM information_schema.columns
+     WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ? LIMIT 1`,
+    [table, column]
+  );
+  return !!row;
+};
+
 // One-time backfill: assign builtin role to existing users based on their gid.
-// Idempotent (PRIMARY KEY (uid, role_id) prevents duplicates).
+// Idempotent (PRIMARY KEY (uid, role_id) prevents duplicates) and conditional
+// on userInfo.gid still existing — once dropped, this is a no-op.
 const backfillUserRoles = async () => {
+  if (!(await columnExists('userInfo', 'gid'))) return;
   const roleByGid = await db.query('SELECT id, legacy_gid FROM roles WHERE legacy_gid IS NOT NULL');
   for (const r of roleByGid) {
     await db.query(
@@ -114,11 +127,25 @@ const backfillUserRoles = async () => {
   }
 };
 
+// Final retirement of the legacy gid field. After backfill, every gid=2/3 user
+// has a moderator/super_admin role row, and the application no longer reads
+// gid anywhere. Dropping the column completes the migration so it can't be
+// silently relied on again. Set DISABLE_DROP_GID=1 to opt out (e.g., during a
+// rollback window where you may want to re-enable old code temporarily).
+const dropLegacyGid = async () => {
+  if (process.env.DISABLE_DROP_GID === '1') return;
+  if (!(await columnExists('userInfo', 'gid'))) return;
+  // Only drop after we've confirmed the backfill ran in this process startup.
+  console.log('[auth] dropping legacy userInfo.gid column');
+  await db.query('ALTER TABLE userInfo DROP COLUMN gid');
+};
+
 const syncPermissionCatalog = async () => {
   await ensureSchema();
   await syncPermissions();
   await syncBuiltinRoles();
   await backfillUserRoles();
+  await dropLegacyGid();
 };
 
 module.exports = { syncPermissionCatalog };

--- a/server/auth/test.js
+++ b/server/auth/test.js
@@ -1,0 +1,603 @@
+// Integration tests for the RBAC permission system. Runs against the real
+// database in server/config.json. The legacy `userInfo.gid` column is dropped
+// during sync (one-time on first start), so this test seeds users without gid
+// and assigns roles directly via user_roles.
+//
+//   node server/auth/test.js
+
+const path = require('path');
+process.chdir(path.join(__dirname, '..'));
+
+const db = require('../db');
+const policy = require('./policy');
+const { syncPermissionCatalog } = require('./sync');
+const { PERMISSIONS, BUILTIN_ROLES, RESOURCE_GRANTABLE } = require('./permissions');
+
+const auth = require('../api/auth');
+
+let pass = 0, fail = 0;
+const results = [];
+const ok = (name) => { pass++; results.push(['ok ', name]); };
+const ko = (name, err) => { fail++; results.push(['FAIL', `${name} -- ${err && err.message ? err.message : err}`]); };
+const assert = (cond, name) => { if (cond) ok(name); else ko(name, 'assertion failed'); };
+const assertEq = (a, b, name) => {
+  if (a === b) ok(name);
+  else ko(name, `expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`);
+};
+const assertSetEq = (got, want, name) => {
+  const A = new Set(got), B = new Set(want);
+  if (A.size !== B.size) return ko(name, `size ${A.size} vs ${B.size}; got=${[...A]} want=${[...B]}`);
+  for (const x of B) if (!A.has(x)) return ko(name, `missing ${x}; got=${[...A]}`);
+  ok(name);
+};
+const test = async (name, fn) => {
+  try { await fn(); }
+  catch (err) { ko(name, err); }
+};
+
+// ----- fake req helpers -----
+const makeReq = (uid, perms) => ({
+  body: {},
+  // recordEvent reads ip + useragent; provide harmless defaults so handlers
+  // don't crash inside the audit-log path during tests.
+  session: { uid, ip: '127.0.0.1' },
+  useragent: { browser: { name: 'test', version: '0' }, os: { name: 'test', version: '0' } },
+  can: (key, scope) => policy.can(perms, key, scope),
+  perms,
+});
+const fakeRes = () => {
+  const r = {
+    statusCode: 200,
+    payload: null,
+    status(s) { r.statusCode = s; return r; },
+    send(p) { r.payload = p; return r; },
+    end() { r.payload = null; return r; },
+  };
+  return r;
+};
+const runHandler = async (handler, req) => {
+  const fns = Array.isArray(handler) ? handler : [handler];
+  const res = fakeRes();
+  for (const fn of fns) {
+    let nextCalled = false;
+    await new Promise((resolve) => {
+      const next = () => { nextCalled = true; resolve(); };
+      const ret = fn(req, res, next);
+      if (ret && typeof ret.then === 'function') ret.then(() => { if (!nextCalled) resolve(); });
+      else if (!nextCalled) resolve();
+    });
+    if (res.statusCode >= 400 || res.payload != null) break;
+  }
+  return res;
+};
+
+// ----- sandbox helpers -----
+let createdUids = [];
+
+const mkUser = async (roleKeys = []) => {
+  const r = await db.query(
+    'INSERT INTO userInfo(name, pwd, reg_time, inUse) VALUES (?,?,NOW(),1)',
+    ['_t_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8), 'x']
+  );
+  createdUids.push(r.insertId);
+  if (roleKeys.length) {
+    const rolesRows = await db.query('SELECT id, `key` FROM roles WHERE `key` IN (?)', [roleKeys]);
+    if (rolesRows.length !== roleKeys.length) {
+      throw new Error('unknown role: ' + roleKeys.filter((k) => !rolesRows.some((r) => r.key === k)).join(','));
+    }
+    const values = rolesRows.map((row) => [r.insertId, row.id, null]);
+    await db.query('INSERT INTO user_roles (uid, role_id, granted_by) VALUES ?', [values]);
+  }
+  return r.insertId;
+};
+
+const cleanupSandbox = async () => {
+  if (createdUids.length) {
+    await db.query('DELETE FROM userInfo WHERE uid IN (?)', [createdUids]);
+  }
+  await db.query("DELETE FROM roles WHERE `key` LIKE 'test\\_%' ESCAPE '\\\\'");
+};
+
+// ============================================================
+//                          TESTS
+// ============================================================
+
+(async () => {
+  try {
+    // -------- 0. Schema sync (idempotent + drops legacy gid) --------
+    await test('syncPermissionCatalog runs without error', async () => {
+      await syncPermissionCatalog();
+    });
+
+    await test('legacy userInfo.gid column is gone after sync', async () => {
+      const row = await db.one(
+        `SELECT 1 FROM information_schema.columns
+         WHERE table_schema = DATABASE() AND table_name='userInfo' AND column_name='gid' LIMIT 1`
+      );
+      assert(!row, 'userInfo.gid column dropped');
+    });
+
+    // -------- 1. Catalog sanity --------
+    await test('all code-defined permissions are upserted', async () => {
+      const rows = await db.query('SELECT `key` FROM permissions');
+      const dbKeys = new Set(rows.map((r) => r.key));
+      for (const k of Object.keys(PERMISSIONS)) {
+        if (!dbKeys.has(k)) throw new Error('missing permission: ' + k);
+      }
+    });
+
+    await test('all builtin roles upserted with builtin=1', async () => {
+      const rows = await db.query("SELECT `key`, builtin, legacy_gid FROM roles WHERE `key` IN (?)", [Object.keys(BUILTIN_ROLES)]);
+      const map = new Map(rows.map((r) => [r.key, r]));
+      for (const [k, meta] of Object.entries(BUILTIN_ROLES)) {
+        const row = map.get(k);
+        if (!row) throw new Error('missing role: ' + k);
+        if (row.builtin !== 1) throw new Error(`role ${k} should have builtin=1`);
+      }
+    });
+
+    await test('moderator role has the unified permission set', async () => {
+      const rows = await db.query(
+        `SELECT p.\`key\` AS k FROM roles r
+         JOIN role_permissions rp ON rp.role_id = r.id
+         JOIN permissions p ON p.id = rp.permission_id
+         WHERE r.\`key\`='moderator'`
+      );
+      assertSetEq(rows.map((r) => r.k), BUILTIN_ROLES.moderator.permissions, 'moderator permission set');
+    });
+
+    await test('super_admin role has every permission', async () => {
+      const rows = await db.query(
+        `SELECT p.\`key\` AS k FROM roles r
+         JOIN role_permissions rp ON rp.role_id = r.id
+         JOIN permissions p ON p.id = rp.permission_id
+         WHERE r.\`key\`='super_admin'`
+      );
+      assertSetEq(rows.map((r) => r.k), Object.keys(PERMISSIONS), 'super_admin includes every permission');
+    });
+
+    // -------- 2. policy.loadEffectivePermissions --------
+    let normalUid, modUid, superUid;
+    await test('seed sandbox users with explicit role assignments', async () => {
+      normalUid = await mkUser([]);
+      modUid = await mkUser(['moderator']);
+      superUid = await mkUser(['super_admin']);
+    });
+
+    await test('normal user has zero global permissions', async () => {
+      policy.invalidate();
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assertEq(p.global.size, 0, 'global set is empty');
+      assertEq(p.denies.size, 0, 'denies set is empty');
+      assertEq(p.scoped.size, 0, 'scoped map is empty');
+    });
+
+    await test('moderator user inherits the moderator permission set', async () => {
+      policy.invalidate();
+      const p = await policy.loadEffectivePermissions(modUid);
+      assertSetEq([...p.global], BUILTIN_ROLES.moderator.permissions, 'moderator effective.global');
+    });
+
+    await test('super_admin user inherits every permission', async () => {
+      policy.invalidate();
+      const p = await policy.loadEffectivePermissions(superUid);
+      assertSetEq([...p.global], Object.keys(PERMISSIONS), 'super_admin effective.global');
+    });
+
+    // -------- 3. user_permissions: global allow + scoped + deny --------
+    await test('grant global allow → appears in effective.global', async () => {
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='contest.create'");
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id) VALUES (?,?,?,?,?)`,
+        [normalUid, perm.id, 'allow', null, null]
+      );
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(p.global.has('contest.create'), 'normal user gained contest.create globally');
+    });
+
+    await test('grant scoped allow → appears in effective.scoped, not in global', async () => {
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='problem.edit.any'");
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id) VALUES (?,?,?,?,?)`,
+        [normalUid, perm.id, 'allow', 'problem', 42]
+      );
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(!p.global.has('problem.edit.any'), 'scoped grant must NOT pollute global set');
+      assert(p.scoped.get('problem.edit.any')?.has('problem:42'), 'scoped grant lands in scoped[problem:42]');
+    });
+
+    await test('policy.can: scoped grant authorizes only the matching scope', async () => {
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(policy.can(p, 'problem.edit.any', { type: 'problem', id: 42 }), 'allowed for pid=42');
+      assert(!policy.can(p, 'problem.edit.any', { type: 'problem', id: 43 }), 'denied for pid=43');
+      assert(!policy.can(p, 'problem.edit.any'), 'no global grant');
+    });
+
+    await test('global deny overrides role-derived allow', async () => {
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='problem.delete.any'");
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id) VALUES (?,?,?,?,?)`,
+        [modUid, perm.id, 'deny', null, null]
+      );
+      policy.invalidate(modUid);
+      const p = await policy.loadEffectivePermissions(modUid);
+      assert(!policy.can(p, 'problem.delete.any'), 'moderator denied problem.delete.any after explicit deny');
+    });
+
+    // -------- 4. Expires honored --------
+    await test('expired allow does not take effect', async () => {
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='announcement.manage'");
+      const past = new Date(Date.now() - 60_000);
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id, expires_at) VALUES (?,?,?,?,?,?)`,
+        [normalUid, perm.id, 'allow', null, null, past]
+      );
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(!p.global.has('announcement.manage'), 'expired grant filtered out');
+    });
+
+    // -------- 5. Cache + invalidate --------
+    await test('policy cache returns the same object until invalidate', async () => {
+      policy.invalidate(superUid);
+      const p1 = await policy.loadEffectivePermissions(superUid);
+      const p2 = await policy.loadEffectivePermissions(superUid);
+      assert(p1 === p2, 'cache reused across calls');
+      policy.invalidate(superUid);
+      const p3 = await policy.loadEffectivePermissions(superUid);
+      assert(p1 !== p3, 'invalidate forces a fresh load');
+    });
+
+    // -------- 6. /api/auth handlers --------
+    const superPerms = await policy.loadEffectivePermissions(superUid);
+    const normalPerms = () => policy.loadEffectivePermissions(normalUid);
+
+    await test('listPermissions returns the catalog (super_admin)', async () => {
+      const req = makeReq(superUid, superPerms);
+      const res = await runHandler(auth.listPermissions, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      assert(Array.isArray(res.payload.permissions), 'permissions array');
+      assert(res.payload.permissions.length >= Object.keys(PERMISSIONS).length, 'has all code-defined keys');
+    });
+
+    await test('listPermissions returns 403 for normal user', async () => {
+      policy.invalidate(normalUid);
+      const req = makeReq(normalUid, await normalPerms());
+      const res = await runHandler(auth.listPermissions, req);
+      assertEq(res.statusCode, 403, 'status 403');
+    });
+
+    await test('listRoles returns roles with permission keys', async () => {
+      const req = makeReq(superUid, superPerms);
+      const res = await runHandler(auth.listRoles, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const sa = res.payload.roles.find((r) => r.key === 'super_admin');
+      assert(sa && sa.permissions.length === Object.keys(PERMISSIONS).length, 'super_admin payload includes every permission');
+    });
+
+    let customRoleId = null;
+    await test('createRole creates a custom role', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'test_custom1', name: '测试角色', description: 'desc', permissionKeys: ['problem.create'] };
+      const res = await runHandler(auth.createRole, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const row = await db.one("SELECT id, builtin FROM roles WHERE `key`=?", ['test_custom1']);
+      assert(row, 'role exists');
+      assertEq(row.builtin, 0, 'builtin=0');
+      customRoleId = row.id;
+      const link = await db.exists(
+        `SELECT 1 FROM role_permissions rp JOIN permissions p ON p.id=rp.permission_id WHERE rp.role_id=? AND p.\`key\`='problem.create'`,
+        [customRoleId]
+      );
+      assert(link, 'role_permissions row created');
+    });
+
+    await test('createRole rejects an illegal key', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'BAD-KEY', name: 'x', permissionKeys: [] };
+      const res = await runHandler(auth.createRole, req);
+      assertEq(res.statusCode, 202, 'status 202 (validation error via fail())');
+      assert(/格式/.test(res.payload.message || ''), 'rejection message about format');
+    });
+
+    await test('updateRole rejects builtin role', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'super_admin', name: 'pwn' };
+      const res = await runHandler(auth.updateRole, req);
+      assertEq(res.statusCode, 202, 'status 202');
+      assert(/内置/.test(res.payload.message || ''), 'rejection message mentions builtin');
+    });
+
+    await test('updateRole modifies a custom role and resets permissions', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'test_custom1', name: '改了名', permissionKeys: ['contest.create', 'problem.create'] };
+      const res = await runHandler(auth.updateRole, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const links = await db.query(
+        `SELECT p.\`key\` AS k FROM role_permissions rp JOIN permissions p ON p.id=rp.permission_id WHERE rp.role_id=?`,
+        [customRoleId]
+      );
+      assertSetEq(links.map((l) => l.k), ['contest.create', 'problem.create'], 'permission set replaced');
+    });
+
+    await test('setUserRoles assigns custom + builtin role to a normal user', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { uid: normalUid, roleKeys: ['test_custom1', 'problem_setter'] };
+      const res = await runHandler(auth.setUserRoles, req);
+      assertEq(res.statusCode, 200, 'status 200');
+
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(p.global.has('problem.create'), 'has problem.create from problem_setter');
+      assert(p.global.has('contest.create'), 'has contest.create from custom role');
+      assert(p.global.has('problem.edit.any'), 'has problem.edit.any from problem_setter');
+    });
+
+    await test('setUserRoles overwrites: removing a role drops its perms', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { uid: normalUid, roleKeys: [] };
+      const res = await runHandler(auth.setUserRoles, req);
+      assertEq(res.statusCode, 200, 'status 200');
+
+      policy.invalidate(normalUid);
+      const p = await policy.loadEffectivePermissions(normalUid);
+      assert(!p.global.has('problem.create'), 'problem.create dropped');
+      // the contest.create grant from the direct user_permissions allow earlier still applies
+      assert(p.global.has('contest.create'), 'direct user_permissions allow survives role clear');
+    });
+
+    await test('deleteRole succeeds for unused custom role', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { key: 'test_custom1' };
+      const res = await runHandler(auth.deleteRole, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const exists = await db.exists("SELECT 1 FROM roles WHERE `key`=?", ['test_custom1']);
+      assert(!exists, 'role removed');
+    });
+
+    await test('deleteRole rejects when role still in use', async () => {
+      const r1 = makeReq(superUid, superPerms);
+      r1.body = { key: 'test_custom2', name: 'x', permissionKeys: [] };
+      await runHandler(auth.createRole, r1);
+      const r2 = makeReq(superUid, superPerms);
+      r2.body = { uid: normalUid, roleKeys: ['test_custom2'] };
+      await runHandler(auth.setUserRoles, r2);
+      const r3 = makeReq(superUid, superPerms);
+      r3.body = { key: 'test_custom2' };
+      const res = await runHandler(auth.deleteRole, r3);
+      assertEq(res.statusCode, 202, 'status 202');
+      assert(/持有/.test(res.payload.message || ''), 'message mentions still in use');
+      const r4 = makeReq(superUid, superPerms);
+      r4.body = { uid: normalUid, roleKeys: [] };
+      await runHandler(auth.setUserRoles, r4);
+      const r5 = makeReq(superUid, superPerms);
+      r5.body = { key: 'test_custom2' };
+      const res2 = await runHandler(auth.deleteRole, r5);
+      assertEq(res2.statusCode, 200, 'cleanup delete ok');
+    });
+
+    await test('grantUserPermission rejects scoped grant on non-scopable key', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = {
+        uid: normalUid, permissionKey: 'problem.create', effect: 'allow',
+        resourceType: 'problem', resourceId: 99,
+      };
+      const res = await runHandler(auth.grantUserPermission, req);
+      assertEq(res.statusCode, 202, 'status 202');
+      assert(/作用域/.test(res.payload.message || ''), 'rejection mentions scope');
+    });
+
+    await test('grantUserPermission upserts scoped allow then revokeUserPermission removes it', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = {
+        uid: normalUid, permissionKey: 'problem.case.manage', effect: 'allow',
+        resourceType: 'problem', resourceId: 7,
+      };
+      const res = await runHandler(auth.grantUserPermission, req);
+      assertEq(res.statusCode, 200, 'grant ok');
+
+      policy.invalidate(normalUid);
+      const p1 = await policy.loadEffectivePermissions(normalUid);
+      assert(p1.scoped.get('problem.case.manage')?.has('problem:7'), 'scoped grant active');
+
+      const req2 = makeReq(superUid, superPerms);
+      req2.body = { ...req.body, expiresAt: new Date(Date.now() + 60_000).toISOString() };
+      const res2 = await runHandler(auth.grantUserPermission, req2);
+      assertEq(res2.statusCode, 200, 'upsert ok');
+      const cnt = await db.one(
+        `SELECT COUNT(*) c FROM user_permissions up JOIN permissions p ON p.id=up.permission_id
+         WHERE up.uid=? AND p.\`key\`='problem.case.manage' AND up.resource_type='problem' AND up.resource_id=7`,
+        [normalUid]
+      );
+      assertEq(cnt.c, 1, 'exactly one row (upserted)');
+
+      const row = await db.one(
+        `SELECT up.id FROM user_permissions up JOIN permissions p ON p.id=up.permission_id
+         WHERE up.uid=? AND p.\`key\`='problem.case.manage' AND up.resource_type='problem' AND up.resource_id=7`,
+        [normalUid]
+      );
+      const req3 = makeReq(superUid, superPerms);
+      req3.body = { id: row.id };
+      const res3 = await runHandler(auth.revokeUserPermission, req3);
+      assertEq(res3.statusCode, 200, 'revoke ok');
+
+      policy.invalidate(normalUid);
+      const p2 = await policy.loadEffectivePermissions(normalUid);
+      assert(!p2.scoped.get('problem.case.manage')?.has('problem:7'), 'scoped grant gone');
+    });
+
+    await test('listUserGrants returns roles + permissions', async () => {
+      const r1 = makeReq(superUid, superPerms);
+      r1.body = { uid: normalUid, roleKeys: ['problem_setter'] };
+      await runHandler(auth.setUserRoles, r1);
+      const r2 = makeReq(superUid, superPerms);
+      r2.body = { uid: normalUid, permissionKey: 'announcement.manage', effect: 'allow' };
+      await runHandler(auth.grantUserPermission, r2);
+
+      const r3 = makeReq(superUid, superPerms);
+      r3.body = { uid: normalUid };
+      const res = await runHandler(auth.listUserGrants, r3);
+      assertEq(res.statusCode, 200, 'status 200');
+      assert(res.payload.roles.includes('problem_setter'), 'roles list includes problem_setter');
+      const perms = res.payload.permissions.map((p) => p.permissionKey);
+      assert(perms.includes('announcement.manage'), 'permissions list includes announcement.manage');
+    });
+
+    await test('searchUsers finds the sandbox normal user by uid', async () => {
+      const req = makeReq(superUid, superPerms);
+      req.body = { q: String(normalUid) };
+      const res = await runHandler(auth.searchUsers, req);
+      assertEq(res.statusCode, 200, 'status 200');
+      const found = res.payload.users.find((u) => u.uid === normalUid);
+      assert(!!found, 'user appears in search results');
+    });
+
+    // -------- 7. Resource-owner authorization path --------
+    await test('resource owner can grant whitelisted permission without user.permission.grant', async () => {
+      const r = await db.query(
+        `INSERT INTO problem(title, description, publisher, time, tags) VALUES (?,?,?,NOW(),?)`,
+        ['_test_problem', 'desc', normalUid, '[]']
+      );
+      const pid = r.insertId;
+
+      try {
+        policy.invalidate(normalUid);
+        const ownerPerms = await policy.loadEffectivePermissions(normalUid);
+        const req = makeReq(normalUid, ownerPerms);
+        req.body = {
+          uid: modUid,
+          permissionKey: 'problem.case.manage',
+          effect: 'allow',
+          resourceType: 'problem',
+          resourceId: pid,
+        };
+        const res = await runHandler(auth.grantUserPermission, req);
+        assertEq(res.statusCode, 200, 'owner-as-grantor ok');
+
+        policy.invalidate(modUid);
+        const mp = await policy.loadEffectivePermissions(modUid);
+        assert(mp.scoped.get('problem.case.manage')?.has(`problem:${pid}`),
+          `modUid has problem.case.manage scoped to problem:${pid}`);
+
+        const req2 = makeReq(normalUid, ownerPerms);
+        req2.body = {
+          uid: modUid,
+          permissionKey: 'problem.view.private',
+          effect: 'allow',
+          resourceType: 'problem',
+          resourceId: pid,
+        };
+        const res2 = await runHandler(auth.grantUserPermission, req2);
+        assert(res2.statusCode !== 200, 'non-whitelisted grant rejected');
+      } finally {
+        await db.query('DELETE FROM user_permissions WHERE resource_type=? AND resource_id=?', ['problem', pid]);
+        await db.query('DELETE FROM problem WHERE pid=?', [pid]);
+      }
+    });
+
+    await test('listResourceGrants returns all grants on a resource for the owner', async () => {
+      const start = new Date();
+      const c = await db.query(
+        `INSERT INTO contest(title, host, start, length, type, isPublic) VALUES (?,?,?,?,?,?)`,
+        ['_test_contest', normalUid, start, 60, 0, 0]
+      );
+      const cid = c.insertId;
+      try {
+        const grant = makeReq(superUid, superPerms);
+        grant.body = { uid: modUid, permissionKey: 'contest.player.manage', effect: 'allow', resourceType: 'contest', resourceId: cid };
+        await runHandler(auth.grantUserPermission, grant);
+
+        policy.invalidate(normalUid);
+        const ownerPerms = await policy.loadEffectivePermissions(normalUid);
+        const req = makeReq(normalUid, ownerPerms);
+        req.body = { resourceType: 'contest', resourceId: cid };
+        const res = await runHandler(auth.listResourceGrants, req);
+        assertEq(res.statusCode, 200, 'owner can list resource grants');
+        assert(res.payload.grants.some((g) => g.uid === modUid && g.permissionKey === 'contest.player.manage'),
+          'returned grant matches');
+        assertSetEq(res.payload.grantablePermissions, RESOURCE_GRANTABLE.contest, 'returns whitelist for contest');
+      } finally {
+        await db.query('DELETE FROM user_permissions WHERE resource_type=? AND resource_id=?', ['contest', cid]);
+        await db.query('DELETE FROM contest WHERE cid=?', [cid]);
+      }
+    });
+
+    // -------- 8. requirePermission middleware --------
+    await test('requirePermission middleware blocks insufficient perms', async () => {
+      const { requirePermission } = require('./middleware');
+      const mw = requirePermission('user.role.assign');
+      // Strip every role + grant from normalUid first.
+      await db.query('DELETE FROM user_roles WHERE uid=?', [normalUid]);
+      await db.query('DELETE FROM user_permissions WHERE uid=?', [normalUid]);
+      policy.invalidate(normalUid);
+      const req = makeReq(normalUid, await policy.loadEffectivePermissions(normalUid));
+      const res = fakeRes();
+      let nextCalled = false;
+      await new Promise((resolve) => {
+        const r = mw(req, res, () => { nextCalled = true; resolve(); });
+        if (r && typeof r.then === 'function') r.then(() => resolve());
+      });
+      assert(!nextCalled, 'next() not called');
+      assertEq(res.statusCode, 403, 'status 403');
+    });
+
+    await test('requirePermission middleware lets super_admin through', async () => {
+      const { requirePermission } = require('./middleware');
+      const mw = requirePermission('user.role.assign');
+      const req = makeReq(superUid, superPerms);
+      const res = fakeRes();
+      let nextCalled = false;
+      await new Promise((resolve) => {
+        const r = mw(req, res, () => { nextCalled = true; resolve(); });
+        if (r && typeof r.then === 'function') r.then(() => resolve());
+      });
+      assert(nextCalled, 'next() called');
+    });
+
+    await test('requirePermission with scopeFrom honors scoped grants', async () => {
+      const { requirePermission } = require('./middleware');
+      const mw = requirePermission('problem.edit.any', {
+        scopeFrom: (req) => ({ type: 'problem', id: +req.body.pid }),
+      });
+      // normalUid currently has no roles/grants — give it ONLY a scoped allow on pid 99.
+      const perm = await db.one("SELECT id FROM permissions WHERE `key`='problem.edit.any'");
+      await db.query(
+        `INSERT INTO user_permissions (uid, permission_id, effect, resource_type, resource_id) VALUES (?,?,?,?,?)`,
+        [normalUid, perm.id, 'allow', 'problem', 99]
+      );
+      policy.invalidate(normalUid);
+      const req = makeReq(normalUid, await policy.loadEffectivePermissions(normalUid));
+      req.body = { pid: 99 };
+      const res = fakeRes();
+      let nextCalled = false;
+      await new Promise((resolve) => {
+        const r = mw(req, res, () => { nextCalled = true; resolve(); });
+        if (r && typeof r.then === 'function') r.then(() => resolve());
+      });
+      assert(nextCalled, 'allowed for pid=99');
+
+      const req2 = makeReq(normalUid, await policy.loadEffectivePermissions(normalUid));
+      req2.body = { pid: 100 };
+      const res2 = fakeRes();
+      let nextCalled2 = false;
+      await new Promise((resolve) => {
+        const r = mw(req2, res2, () => { nextCalled2 = true; resolve(); });
+        if (r && typeof r.then === 'function') r.then(() => resolve());
+      });
+      assert(!nextCalled2, 'blocked for pid=100');
+      assertEq(res2.statusCode, 403, 'status 403');
+    });
+  } catch (err) {
+    console.error('FATAL:', err && err.stack ? err.stack : err);
+    fail++;
+  } finally {
+    await cleanupSandbox().catch((e) => console.error('cleanup error:', e));
+    for (const [tag, msg] of results) {
+      console.log(`  ${tag} ${msg}`);
+    }
+    console.log(`\n${pass} passed, ${fail} failed`);
+    db.pool.end(() => process.exit(fail ? 1 : 0));
+  }
+})();

--- a/server/db/util.js
+++ b/server/db/util.js
@@ -12,13 +12,6 @@ const handler = (fn) => async (req, res, next) => {
 const fail = (res, message, status = 202) => res.status(status).send({ message });
 const ok = (res, payload = { message: 'success' }) => res.status(200).send(payload);
 
-const requireRole = (minGid) => (req, res, next) => {
-  if ((req.session.gid || 1) < minGid) {
-    return res.status(403).end('403 Forbidden');
-  }
-  return next();
-};
-
 const paginate = (req, defaultSize = 20) => {
   let pageId = parseInt(req.body.pageId, 10);
   if (!pageId || pageId < 1) pageId = 1;
@@ -43,4 +36,4 @@ const buildWhere = (conditions, prefix = '') => {
   return { where: head + parts.join(' AND '), params };
 };
 
-module.exports = { handler, fail, ok, requireRole, paginate, buildWhere };
+module.exports = { handler, fail, ok, paginate, buildWhere };

--- a/web/src/assets/common.js
+++ b/web/src/assets/common.js
@@ -1,5 +1,7 @@
-export const getNameColor = (gid, cnt) => {
-  if (gid !== 1)
+// Staff (any moderator+ role) get a distinct purple. The server attaches an
+// `isStaff` flag on rabbit/leaderboard rows derived from the role table.
+export const getNameColor = (isStaff, cnt) => {
+  if (isStaff)
     return "#8e44ad";
   else if (cnt < 1000)
     return "#606266";
@@ -53,7 +55,6 @@ export const refreshUserInfo = async () => {
     if (res.status === 200) {
       store.state.uid = res.data.uid;
       store.state.name = res.data.name;
-      store.state.gid = res.data.gid;
       store.state.ip = res.data.ip;
       store.state.avatar = res.data.avatar;
       store.state.preferenceLang = res.data.preferenceLang;

--- a/web/src/components/admin/permissionCenter.vue
+++ b/web/src/components/admin/permissionCenter.vue
@@ -23,10 +23,9 @@
           <div v-if="!pickedUid" style="color:#909399; padding: 20px;">请选择一个用户。</div>
 
           <div v-else>
-            <el-descriptions :column="3" border>
+            <el-descriptions :column="2" border>
               <el-descriptions-item label="uid">{{ userInfo.uid }}</el-descriptions-item>
               <el-descriptions-item label="用户名">{{ userInfo.name }}</el-descriptions-item>
-              <el-descriptions-item label="主 gid">{{ userInfo.gid }}</el-descriptions-item>
             </el-descriptions>
 
             <el-divider>角色</el-divider>
@@ -74,7 +73,6 @@
                 <el-tag size="small" type="info" v-else>自定义</el-tag>
               </template>
             </el-table-column>
-            <el-table-column label="legacy gid" width="110" prop="legacy_gid" />
             <el-table-column label="权限数" width="90">
               <template #default="scope">{{ (scope.row.permissions || []).length }}</template>
             </el-table-column>
@@ -132,7 +130,7 @@ export default {
       permissions: [],
       roles: [],
       pickedUid: null,
-      userInfo: { uid: 0, name: '', gid: 0 },
+      userInfo: { uid: 0, name: '' },
       userRoleKeys: [],
       originalRoleKeys: [],
       userPermissions: [],
@@ -178,14 +176,14 @@ export default {
     },
     onUserPicked(picked) {
       if (picked) this.loadUserGrants();
-      else { this.userInfo = { uid: 0, name: '', gid: 0 }; this.userRoleKeys = []; this.userPermissions = []; }
+      else { this.userInfo = { uid: 0, name: '' }; this.userRoleKeys = []; this.userPermissions = []; }
     },
     async loadUserGrants() {
       if (!this.pickedUid) return;
       try {
         const res = await axios.post('/api/auth/listUserGrants', { uid: this.pickedUid });
         if (res.status !== 200) { this.$message.error(res.data && res.data.message || '加载失败'); return; }
-        this.userInfo = res.data.user || { uid: this.pickedUid, name: '', gid: 0 };
+        this.userInfo = res.data.user || { uid: this.pickedUid, name: '' };
         this.userRoleKeys = res.data.roles || [];
         this.originalRoleKeys = [...this.userRoleKeys];
         this.userPermissions = res.data.permissions || [];

--- a/web/src/components/admin/userManage.vue
+++ b/web/src/components/admin/userManage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="text-align: center; margin: 0 auto; max-width: 1200px">
+  <div style="text-align: center; margin: 0 auto; max-width: 1300px">
     <el-card class="box-card" shadow="hover">
       <template #header>
         <div class="card-header">
@@ -13,31 +13,21 @@
         :header-cell-style="{ textAlign: 'center' }" v-loading="!loadingFinished">
         <el-table-column prop="uid" width="110px">
           <template #header>
-            <div class="table-header">
-              uid
-            </div>
+            <div class="table-header">uid</div>
             <el-input v-model="filter.uid" size="small" style="width: 80px;" @keyup.enter="all">
               <template #prefix>
-                <el-icon class="el-input__icon">
-                  <search />
-                </el-icon>
+                <el-icon class="el-input__icon"><search /></el-icon>
               </template>
             </el-input>
           </template>
-          <template #default="scope">
-            {{ scope.row.uid }}
-          </template>
+          <template #default="scope">{{ scope.row.uid }}</template>
         </el-table-column>
-        <el-table-column prop="name" width="150px">
+        <el-table-column prop="name" width="160px">
           <template #header>
-            <div class="table-header">
-              用户名
-            </div>
-            <el-input v-model="filter.name" size="small" style="width: 120px;" @keyup.enter="all">
+            <div class="table-header">用户名</div>
+            <el-input v-model="filter.name" size="small" style="width: 130px;" @keyup.enter="all">
               <template #prefix>
-                <el-icon class="el-input__icon">
-                  <search />
-                </el-icon>
+                <el-icon class="el-input__icon"><search /></el-icon>
               </template>
             </el-input>
           </template>
@@ -45,76 +35,60 @@
             <router-link :to="'/user/' + scope.row.uid" class="rlink" v-show="!scope.row.edit">
               {{ scope.row.name }}
             </router-link>
-            <el-input v-show="scope.row.edit" size="small" style="width:110px" v-model="this.tempInfo.name" />
+            <el-input v-show="scope.row.edit" size="small" style="width:120px" v-model="this.tempInfo.name" />
           </template>
         </el-table-column>
-        <el-table-column prop="email" width="300px">
+        <el-table-column prop="email" width="280px">
           <template #header>
-            <div class="table-header">
-              邮箱
-            </div>
+            <div class="table-header">邮箱</div>
             <el-input v-model="filter.email" size="small" style="width: 200px;" @keyup.enter="all">
               <template #prefix>
-                <el-icon class="el-input__icon">
-                  <search />
-                </el-icon>
+                <el-icon class="el-input__icon"><search /></el-icon>
               </template>
             </el-input>
           </template>
           <template #default="scope">
-            <span v-show="!scope.row.edit"> {{ scope.row.email }} </span>
+            <span v-show="!scope.row.edit">{{ scope.row.email }}</span>
             <el-input v-show="scope.row.edit" size="small" style="width:200px" v-model="this.tempInfo.email" />
           </template>
         </el-table-column>
-        <el-table-column prop="gid" width="140px">
+        <el-table-column prop="roles" width="240px">
           <template #header>
-            <div class="table-header">
-              用户组
-            </div>
-            <el-select v-model="filter.gid" class="m-2" size="small" style="width: 100px;">
-              <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value"
-                style="width: 100px; font-size: 12px; padding-left: 10px; padding-right: 10px;" />
+            <div class="table-header">角色</div>
+            <el-select v-model="filter.roleKey" size="small" style="width: 180px;" clearable placeholder="按角色筛选" @change="all">
+              <el-option v-for="r in roles" :key="r.key" :label="r.name" :value="r.key" />
             </el-select>
           </template>
           <template #default="scope">
-            <span v-show="!scope.row.edit"> {{ group[scope.row.gid] }}</span>
-            <el-select v-show="scope.row.edit" v-model="this.tempInfo.gid" size="small" style="width: 100px">
-              <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value"
-                style="width: 100px; font-size: 12px; padding-left: 10px; padding-right: 10px;" />
-            </el-select>
+            <el-tag v-for="rk in (scope.row.roles || [])" :key="rk" size="small" style="margin: 1px;">
+              {{ roleName(rk) }}
+            </el-tag>
+            <span v-if="!(scope.row.roles && scope.row.roles.length)" style="color:#909399">（无）</span>
           </template>
         </el-table-column>
         <el-table-column prop="inUse" width="auto">
           <template #header>
-            <div class="table-header">
-              状态
-            </div>
-            <el-select v-model="filter.inUse" class="m-2" size="small" style="width: 80px;">
-              <el-option v-for="item in status" :key="item.value" :label="item.label" :value="item.value"
-                style="width: 80px; font-size: 12px; padding-left: 20px; padding-right: 20px;" />
+            <div class="table-header">状态</div>
+            <el-select v-model="filter.inUse" size="small" style="width: 90px;">
+              <el-option v-for="item in status" :key="item.value" :label="item.label" :value="item.value" />
             </el-select>
           </template>
           <template #default="scope">
-            <span> {{ scope.row.inUse ? "正常" : "封禁" }}</span>
+            <span>{{ scope.row.inUse ? "正常" : "封禁" }}</span>
           </template>
         </el-table-column>
         <el-table-column fixed="right" width="360px">
           <template #header>
-            <div class="table-header">
-              操作
-            </div>
-            <el-button size="small" @click="this.all">
-              筛选记录
-            </el-button>
-            <el-button size="small" @click="clear">
-              显示全部
-            </el-button>
+            <div class="table-header">操作</div>
+            <el-button size="small" @click="this.all">筛选记录</el-button>
+            <el-button size="small" @click="clear">显示全部</el-button>
           </template>
           <template #default="scope">
             <span>
-              <el-button size="small" :type="scope.row.edit ? 'warning' : 'primary'" plain @click="edit(scope.row)">{{
-                scope.row.edit ? "保存信息" : "编辑信息" }}</el-button>
-              <el-button size="small" :type="scope.row.inUse ? 'danger' : 'success'" plain
+              <el-button size="small" :type="scope.row.edit ? 'warning' : 'primary'" plain @click="edit(scope.row)" v-if="$can('user.edit')">
+                {{ scope.row.edit ? "保存信息" : "编辑信息" }}
+              </el-button>
+              <el-button size="small" :type="scope.row.inUse ? 'danger' : 'success'" plain v-if="$can('user.ban')"
                 @click="setBlock(scope.row.uid, !scope.row.inUse)">
                 {{ scope.row.inUse ? "封禁账号" : "解除封禁" }}
               </el-button>
@@ -135,7 +109,7 @@ import axios from "axios"
 import qs from 'qs'
 
 export default {
-  name: 'cuteRank',
+  name: 'userManage',
   data() {
     return {
       total: 0,
@@ -143,52 +117,45 @@ export default {
       currentPage: 1,
       loadingFinished: false,
       info: [],
-      group: ['', '普通用户', '管理员', '超级管理员'],
+      roles: [],            // catalog from /api/auth/listRoles
       tempInfo: {},
       filter: {
         uid: null,
         name: null,
         email: null,
-        gid: null,
-        inUse: null
+        roleKey: null,
+        inUse: null,
       },
-      options: [{
-        value: 1,
-        label: '普通用户',
-      }, {
-        value: 2,
-        label: '管理员',
-      }, {
-        value: 3,
-        label: '超级管理员',
-      }],
-      status: [{
-        value: 1,
-        label: '正常',
-      }, {
-        value: 2,
-        label: '封禁',
-      }]
+      status: [{ value: 1, label: '正常' }, { value: 2, label: '封禁' }],
     }
   },
   methods: {
+    roleName(key) {
+      const r = this.roles.find((x) => x.key === key);
+      return r ? r.name : key;
+    },
+    async loadRoles() {
+      try {
+        const res = await axios.post('/api/auth/listRoles');
+        if (res.status === 200) this.roles = (res.data && res.data.roles) || [];
+      } catch (_) { /* allowed to fail silently — table still renders raw keys */ }
+    },
     all() {
       this.loadingFinished = false;
       let param = {}, url = location.pathname;
       if (this.filter.uid) param.uid = this.filter.uid;
       if (this.filter.name) param.name = this.filter.name;
       if (this.filter.email) param.email = this.filter.email;
-      if (this.filter.gid) param.gid = this.filter.gid;
+      if (this.filter.roleKey) param.roleKey = this.filter.roleKey;
       if (this.filter.inUse) param.inUse = this.filter.inUse;
-      if (this.currentPage > 1)
-        param.pageId = this.currentPage;
+      if (this.currentPage > 1) param.pageId = this.currentPage;
       let nurl = qs.stringify(param);
       if (nurl) url += ('?' + nurl);
       history.state.current = url;
       history.replaceState(history.state, null, url);
       axios.post('/api/admin/getUserInfoList', {
         pageId: this.currentPage,
-        filter: this.filter
+        filter: this.filter,
       }).then(res => {
         this.loadingFinished = true;
         this.total = res.data.total;
@@ -198,7 +165,7 @@ export default {
       });
     },
     clear() {
-      this.filter = { uid: null, name: null, email: null, gid: null, inUse: null };
+      this.filter = { uid: null, name: null, email: null, roleKey: null, inUse: null };
       this.all();
     },
     handleCurrentChange(val) {
@@ -210,46 +177,24 @@ export default {
         this.$message.error('请先保存上一次操作');
         return;
       }
-      axios.post('/api/admin/setBlock', {
-        uid: uid,
-        status: status
-      }).then((res) => {
+      axios.post('/api/admin/setBlock', { uid, status }).then((res) => {
         if (res.status === 200) {
           this.all();
           this.$message.success('操作成功');
         }
-      }).catch(err => {
-        this.$message.error(err.message);
-      });
+      }).catch(err => this.$message.error(err.message));
     },
     edit(row) {
       if (row.edit) {
-        axios.post('/api/admin/updateUserInfo', {
-          info: this.tempInfo
-        }).then((res) => {
-          if (res.status === 200) {
-            this.all();
-            this.$message.success('操作成功');
-          }
-          else {
-            this.$message.error(res.data.message);
-          }
-        }).catch(err => {
-          this.$message.error(err.message);
-        });
+        axios.post('/api/admin/updateUserInfo', { info: this.tempInfo }).then((res) => {
+          if (res.status === 200) { this.all(); this.$message.success('操作成功'); }
+          else this.$message.error(res.data.message);
+        }).catch(err => this.$message.error(err.message));
         this.finished = 1;
       } else {
-        if (!this.finished) {
-          this.$message.error('请先保存上一次操作');
-          return;
-        }
+        if (!this.finished) { this.$message.error('请先保存上一次操作'); return; }
         this.finished = 0;
-        this.tempInfo = {
-          uid: row.uid,
-          name: row.name,
-          email: row.email,
-          gid: row.gid
-        };
+        this.tempInfo = { uid: row.uid, name: row.name, email: row.email };
       }
       row.edit ^= 1;
     },
@@ -257,34 +202,27 @@ export default {
       this.$router.push({ path: '/admin/permissions', query: { tab: 'userGrants', uid } });
     },
   },
-  mounted() {
+  async mounted() {
     let query = this.$route.query;
     if (query.uid) this.filter.uid = query.uid;
     if (query.name) this.filter.name = query.name;
     if (query.email) this.filter.email = query.email;
-    if (query.gid) this.filter.gid = parseInt(query.gid);
+    if (query.roleKey) this.filter.roleKey = query.roleKey;
     if (query.inUse) this.filter.inUse = parseInt(query.inUse);
     if (query.pageId) this.currentPage = parseInt(query.pageId);
+    await this.loadRoles();
     this.all();
   },
 }
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.box-card {
-  margin: 10px;
-}
-
+.box-card { margin: 10px; }
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   height: 20px;
 }
-
-.table-header {
-  text-align: center;
-  height: 30px;
-}
+.table-header { text-align: center; height: 30px; }
 </style>

--- a/web/src/components/announcement/announcementEdit.vue
+++ b/web/src/components/announcement/announcementEdit.vue
@@ -32,7 +32,6 @@ export default {
   data() {
     return {
       aid: 0,
-      gid: 1,
       announcementInfo: {},
     }
   },
@@ -59,7 +58,7 @@ export default {
     }
   },
   mounted() {
-    if (this.$store.state.gid < 3) {
+    if (!this.$can('announcement.manage')) {
       this.$router.push('/announcement/' + this.$route.params.aid);
     }
     this.aid = this.$route.params.aid;

--- a/web/src/components/announcement/announcementView.vue
+++ b/web/src/components/announcement/announcementView.vue
@@ -6,7 +6,7 @@
           <div class="card-header">
             <p class="title">{{ announcementInfo.title }}</p>
             <p class="time">{{ announcementInfo.time }}</p>
-            <el-button v-if="this.gid === 3" type="danger" style="float: right;"
+            <el-button v-if="$can('announcement.manage')" type="danger" style="float: right;"
               @click="this.$router.push('/announcement/edit/' + announcementInfo.aid)">
               <el-icon class="el-icon--left">
                 <Edit />
@@ -29,13 +29,11 @@ export default {
   data() {
     return {
       aid: 0,
-      gid: 1,
       announcementInfo: {},
     }
   },
   async mounted() {
     this.aid = this.$route.params.aid;
-    this.gid = this.$store.state.gid;
     await axios.post('/api/common/getAnnouncementInfo', { aid: this.aid }).then(res => {
       if (res.status === 200)
         this.announcementInfo = res.data.data

--- a/web/src/components/contest/components/contestProblemList.vue
+++ b/web/src/components/contest/components/contestProblemList.vue
@@ -42,7 +42,6 @@ export default {
   data() {
     return {
       problemList: [],
-      gid: 1,
       cid: 0,
       finished: false
     }
@@ -73,7 +72,6 @@ export default {
   },
   mounted() {
     this.cid = this.$route.params.cid;
-    this.gid = this.$store.state.gid;
     this.all();
   }
 }

--- a/web/src/components/contest/components/contestRank.vue
+++ b/web/src/components/contest/components/contestRank.vue
@@ -96,7 +96,6 @@ export default {
       subList: [],
       isProblem: false,
       dialogVisible: false,
-      gid: 1,
       cid: 0,
       finished: false
     };
@@ -186,7 +185,6 @@ export default {
     }
   },
   mounted() {
-    this.gid = this.$store.state.gid;
     this.cid = this.$route.params.cid;
     this.all();
   },

--- a/web/src/components/contest/components/problemManage.vue
+++ b/web/src/components/contest/components/problemManage.vue
@@ -78,7 +78,6 @@ export default {
     return {
       problemList: [],
       total: 0,
-      gid: 1,
       cid: 0,
       currentPage: 1,
       addpid: '',

--- a/web/src/components/contest/contestList.vue
+++ b/web/src/components/contest/contestList.vue
@@ -7,7 +7,7 @@
           <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
             layout="total, prev, pager, next" :total="total"></el-pagination>
           <el-button-group>
-            <el-popconfirm v-if="this.gid >= 2" confirm-button-text="确认" cancel-button-text="取消" title="确认添加比赛?"
+            <el-popconfirm v-if="$can('contest.create')" confirm-button-text="确认" cancel-button-text="取消" title="确认添加比赛?"
               @confirm="addContest">
               <template #reference>
                 <el-button type="success">
@@ -91,7 +91,6 @@ export default {
     return {
       contestList: [],
       total: 0,
-      gid: 1,
       finished: false,
       currentPage: 1,
       tagType: {
@@ -135,7 +134,6 @@ export default {
     },
   },
   async mounted() {
-    this.gid = this.$store.state.gid;
     this.all();
   }
 }

--- a/web/src/components/contest/contestMain.vue
+++ b/web/src/components/contest/contestMain.vue
@@ -68,7 +68,7 @@
               </template>
               <contestRank ref="rank" />
             </el-tab-pane>
-            <el-tab-pane name="manageC" v-if="this.gid >= 2">
+            <el-tab-pane name="manageC" v-if="canManage">
               <template #label>
                 <el-icon style="margin: 4px;">
                   <SetUp />
@@ -137,7 +137,7 @@
                 </el-col>
               </el-row>
             </el-tab-pane>
-            <el-tab-pane name="manageP" v-if="this.gid >= 2">
+            <el-tab-pane name="manageP" v-if="canManage">
               <template #label>
                 <el-icon style="margin: 4px;">
                   <SetUp />
@@ -145,6 +145,15 @@
                 题目管理
               </template>
               <problemManage ref="manageP" />
+            </el-tab-pane>
+            <el-tab-pane name="collaborators" v-if="canManage">
+              <template #label>
+                <el-icon style="margin: 4px;">
+                  <Lock />
+                </el-icon>
+                协作者
+              </template>
+              <CollaboratorPanel resource-type="contest" :resource-id="parseInt(cid)" :visible="canManage" />
             </el-tab-pane>
           </el-tabs>
         </el-card>
@@ -159,6 +168,7 @@ import contestSubmission from './components/contestSubmission.vue'
 import contestRank from './components/contestRank.vue'
 import contestProblemList from './components/contestProblemList.vue'
 import problemManage from './components/problemManage.vue'
+import CollaboratorPanel from '@/components/permission/CollaboratorPanel.vue'
 
 export default {
   name: "contestMain",
@@ -166,12 +176,23 @@ export default {
     contestSubmission,
     contestRank,
     contestProblemList,
-    problemManage
+    problemManage,
+    CollaboratorPanel,
+  },
+  computed: {
+    // Visible to the host or anyone with global contest.edit.any.
+    // The server's contestInfo.auth.manage is authoritative; mirror it here
+    // when present, falling back to a client-side guess for first paint.
+    canManage() {
+      if (this.contestInfo && this.contestInfo.auth && this.contestInfo.auth.manage !== undefined)
+        return this.contestInfo.auth.manage;
+      if (this.contestInfo && this.contestInfo.host === this.$store.state.uid) return true;
+      return this.$can('contest.edit.any');
+    },
   },
   data() {
     return {
       cid: 0,
-      gid: 1,
       contestInfo: {},
       tmpInfo: {},
       activeName: '',
@@ -302,7 +323,6 @@ export default {
   mounted() {
     this.cid = this.$route.params.cid;
     this.activeName = this.$route.query.tab || 'main';
-    this.gid = this.$store.state.gid;
     this.all();
   },
   beforeUnmount() {

--- a/web/src/components/contest/contestPlayer.vue
+++ b/web/src/components/contest/contestPlayer.vue
@@ -7,26 +7,26 @@
           <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
             layout="total, prev, pager, next" :total="total"></el-pagination>
           <el-button-group>
-            <el-button v-if="this.gid >= 2" type="danger" @click="removePlayer" :disabled="!removeList.length">
+            <el-button v-if="$canAny('contest.edit.any','contest.player.manage')" type="danger" @click="removePlayer" :disabled="!removeList.length">
               <el-icon class="el-icon--left">
                 <Remove />
               </el-icon>
               踢出
             </el-button>
-            <el-button v-if="this.gid >= 2" type="success" :disabled="!addName.length" @click="addPlayer">
+            <el-button v-if="$canAny('contest.edit.any','contest.player.manage')" type="success" :disabled="!addName.length" @click="addPlayer">
               <el-icon class="el-icon--left">
                 <Plus />
               </el-icon>
               添加
             </el-button>
-            <el-input v-if="this.gid >= 2" v-model="addName" style="width: 150px;" placeholder="添加用户名"
+            <el-input v-if="$canAny('contest.edit.any','contest.player.manage')" v-model="addName" style="width: 150px;" placeholder="添加用户名"
               @keyup.enter="addPlayer" />
           </el-button-group>
         </div>
       </template>
       <el-table :data="playerList" height="600px" @selection-change="select" :header-cell-style="{ textAlign: 'center' }"
         :cell-style="{ textAlign: 'center' }" v-loading="!finished">
-        <el-table-column v-if="this.gid >= 2" type="selection" min-width="10%" />
+        <el-table-column v-if="$canAny('contest.edit.any','contest.player.manage')" type="selection" min-width="10%" />
         <el-table-column prop="uid" label="uid" min-width="20%" />
         <el-table-column prop="name" label="用户名" min-width="70%">
           <template #default="scope">
@@ -51,7 +51,6 @@ export default {
       removeList: [],
       total: 0,
       finished: false,
-      gid: 1,
       cid: 0,
       currentPage: 1,
       addName: '',
@@ -108,7 +107,6 @@ export default {
   },
   mounted() {
     this.cid = this.$route.params.cid;
-    this.gid = this.$store.state.gid;
     this.all();
   }
 }

--- a/web/src/components/contest/contestProblem.vue
+++ b/web/src/components/contest/contestProblem.vue
@@ -73,7 +73,7 @@
             </el-icon>
             返回比赛
           </el-button>
-          <el-button v-if="this.gid >= 2" type="warning" @click="this.$router.push('/problem/' + problemInfo.pid)">
+          <el-button v-if="$can('contest.edit.any')" type="warning" @click="this.$router.push('/problem/' + problemInfo.pid)">
             <el-icon class="el-icon--left">
               <Files />
             </el-icon>
@@ -95,7 +95,6 @@ export default {
     return {
       cid: 0,
       pid: 0,
-      gid: 1,
       submitLang: null,
       langList: [],
       problemInfo: {},
@@ -135,7 +134,6 @@ export default {
   async mounted() {
     this.cid = this.$route.params.cid;
     this.idx = this.$route.params.idx;
-    this.gid = this.$store.state.gid;
     await axios.post("/api/contest/getProblemInfo", { cid: this.cid, idx: this.idx }).then(res => {
       if (res.status === 200) {
         this.problemInfo = res.data.data;

--- a/web/src/components/indexPage.vue
+++ b/web/src/components/indexPage.vue
@@ -5,7 +5,7 @@
         <template #header>
           <div class="card-header">
             公告栏
-            <el-popconfirm v-if="gid === 3" confirm-button-text="确认" cancel-button-text="取消" title="确认添加公告?"
+            <el-popconfirm v-if="$can('announcement.manage')" confirm-button-text="确认" cancel-button-text="取消" title="确认添加公告?"
               @confirm="addAnnouncement">
               <template #reference>
                 <el-button type="danger">
@@ -67,7 +67,6 @@ export default {
     return {
       motto: {},
       announcements: [],
-      gid: 0,
     }
   },
   methods: {
@@ -99,7 +98,6 @@ export default {
     }
   },
   mounted() {
-    this.gid = this.$store.state.gid;
     this.updateHitokoto();
     this.getAnnouncements();
   },

--- a/web/src/components/myHeader.vue
+++ b/web/src/components/myHeader.vue
@@ -56,7 +56,7 @@
         </el-icon>
         编辑资料
       </el-menu-item>
-      <el-menu-item v-if="this.$store.state.gid === 3" index="/admin/usermanage">
+      <el-menu-item v-if="$canAny('user.list','user.edit','user.ban')" index="/admin/usermanage">
         <el-icon>
           <Operation />
         </el-icon>
@@ -95,7 +95,6 @@ export default {
     return {
       uid: 0,
       name: "/",
-      gid: 1,
       money: 50,
       curPath: '',
       options: [{
@@ -115,7 +114,7 @@ export default {
       axios.post('/api/user/logout').then(() => {
         this.$store.state.uid = 0;
         this.$store.state.name = '/';
-        this.$store.state.gid = 0;
+        this.$store.commit('setPermissions', []);
         this.$router.push('/');
       });
     }

--- a/web/src/components/paste/pasteEdit.vue
+++ b/web/src/components/paste/pasteEdit.vue
@@ -6,10 +6,10 @@
           <div class="card-header">
             <p class="title">
               标题：<el-input v-model="paste.title" style="width: 200px; margin-right: 20px;" />
-              <el-switch :disabled="!($store.state.gid > 2 || $store.state.uid === paste.uid)" v-model="paste.isPublic" size="large" active-text="公开" inactive-text="私有" />
+              <el-switch :disabled="!($can('paste.edit.any') || $store.state.uid === paste.uid)" v-model="paste.isPublic" size="large" active-text="公开" inactive-text="私有" />
             </p>
             <el-button-group style="float: right;">
-              <el-button v-if="$store.state.gid > 2 || $store.state.uid === paste.uid" type="danger"
+              <el-button v-if="$can('paste.edit.any') || $store.state.uid === paste.uid" type="danger"
                 @click="updatePaste">更新剪贴板</el-button>
               <el-button type="primary" @click="this.$router.push('/paste/' + paste.mark)">返回剪贴板</el-button>
             </el-button-group>

--- a/web/src/components/paste/pasteView.vue
+++ b/web/src/components/paste/pasteView.vue
@@ -17,7 +17,7 @@
               </span>
             </div>
             <div style="float: right;">
-              <el-button-group v-if="this.gid === 3 || this.$store.state.uid === paste.uid" style="">
+              <el-button-group v-if="$can('paste.edit.any') || this.$store.state.uid === paste.uid" style="">
                 <el-popconfirm confirm-button-text="确认" cancel-button-text="取消" title="确认删除剪贴板?" @confirm="delPaste">
                   <template #reference>
                     <el-button type="warning">
@@ -52,7 +52,6 @@ export default {
   data() {
     return {
       mark: '',
-      gid: 1,
       paste: {},
     }
   },
@@ -81,7 +80,6 @@ export default {
   },
   async mounted() {
     this.mark = this.$route.params.mark;
-    this.gid = this.$store.state.gid;
     this.all();
   }
 }

--- a/web/src/components/permission/CollaboratorPanel.vue
+++ b/web/src/components/permission/CollaboratorPanel.vue
@@ -1,0 +1,179 @@
+<template>
+  <el-card class="box-card" shadow="hover" v-loading="loading">
+    <template #header>
+      <div class="card-header">
+        <span>协作者权限</span>
+        <el-tag size="small" type="info">{{ resourceType }} #{{ resourceId }}</el-tag>
+      </div>
+    </template>
+
+    <div v-if="!visible" style="color:#909399;">无权限管理本资源的协作者。</div>
+    <div v-else>
+      <el-table :data="grants" :cell-style="{ textAlign: 'center' }" :header-cell-style="{ textAlign: 'center' }">
+        <el-table-column label="用户" width="200">
+          <template #default="scope">
+            <router-link :to="'/user/' + scope.row.uid" class="rlink">{{ scope.row.name }} (#{{ scope.row.uid }})</router-link>
+          </template>
+        </el-table-column>
+        <el-table-column label="权限">
+          <template #default="scope">
+            <el-tag size="small">{{ permName(scope.row.permissionKey) }}</el-tag>
+            <div style="font-size:12px;color:#909399;">{{ scope.row.permissionKey }}</div>
+          </template>
+        </el-table-column>
+        <el-table-column label="过期" width="180">
+          <template #default="scope">
+            <span v-if="scope.row.expiresAt">{{ formatDate(scope.row.expiresAt) }}</span>
+            <span v-else style="color:#909399">永久</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="100">
+          <template #default="scope">
+            <el-button type="danger" size="small" plain @click="revoke(scope.row)">移除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-divider>添加协作者</el-divider>
+      <el-form :inline="true">
+        <el-form-item label="用户">
+          <UserPicker v-model="form.uid" style="width: 240px;" />
+        </el-form-item>
+        <el-form-item label="权限">
+          <PermissionPicker
+            v-model="form.permissionKey"
+            :permissions="permissions"
+            :whitelist="grantablePermissions"
+            scopable-only
+            style="width: 240px;"
+          />
+        </el-form-item>
+        <el-form-item label="过期">
+          <el-date-picker v-model="form.expiresAt" type="datetime" placeholder="（永久）" style="width: 200px;" />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" :loading="granting" @click="grant">添加</el-button>
+        </el-form-item>
+      </el-form>
+    </div>
+  </el-card>
+</template>
+
+<script>
+import axios from 'axios';
+import { ElMessageBox } from 'element-plus';
+import UserPicker from './UserPicker.vue';
+import PermissionPicker from './PermissionPicker.vue';
+
+export default {
+  name: 'CollaboratorPanel',
+  components: { UserPicker, PermissionPicker },
+  props: {
+    resourceType: { type: String, required: true },   // 'problem' | 'contest'
+    resourceId: { type: Number, required: true },
+    // visibility decided by parent (e.g. owner OR has *.edit.any). When false, panel renders an empty hint.
+    visible: { type: Boolean, default: true },
+  },
+  data() {
+    return {
+      loading: false,
+      granting: false,
+      grants: [],
+      grantablePermissions: [],
+      permissions: [],
+      form: { uid: null, permissionKey: null, expiresAt: null },
+    };
+  },
+  watch: {
+    resourceId() { this.reload(); },
+    visible(v) { if (v) this.reload(); },
+  },
+  mounted() {
+    if (this.visible) this.reload();
+  },
+  methods: {
+    permName(key) {
+      const p = this.permissions.find((x) => x.key === key);
+      return p ? p.name : key;
+    },
+    formatDate(v) {
+      if (!v) return '';
+      const d = new Date(v);
+      const pad = (n) => (n < 10 ? '0' + n : n);
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    },
+    async reload() {
+      if (!this.resourceId) return;
+      this.loading = true;
+      try {
+        const [pr, gr] = await Promise.all([
+          axios.post('/api/auth/listPermissions').catch(() => ({ data: { permissions: [] } })),
+          axios.post('/api/auth/listResourceGrants', {
+            resourceType: this.resourceType,
+            resourceId: this.resourceId,
+          }),
+        ]);
+        this.permissions = (pr.data && pr.data.permissions) || [];
+        if (gr.status === 200) {
+          this.grants = gr.data.grants || [];
+          this.grantablePermissions = gr.data.grantablePermissions || [];
+        } else if (gr.status !== 403) {
+          this.$message.error(gr.data && gr.data.message || '加载失败');
+        }
+      } catch (e) {
+        if (e.response && e.response.status === 403) {
+          this.grants = [];
+        } else {
+          this.$message.error(e.message || '加载失败');
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+    async grant() {
+      if (!this.form.uid) { this.$message.error('请选择用户'); return; }
+      if (!this.form.permissionKey) { this.$message.error('请选择权限'); return; }
+      this.granting = true;
+      try {
+        const res = await axios.post('/api/auth/grantUserPermission', {
+          uid: this.form.uid,
+          permissionKey: this.form.permissionKey,
+          effect: 'allow',
+          resourceType: this.resourceType,
+          resourceId: this.resourceId,
+          expiresAt: this.form.expiresAt || null,
+        });
+        if (res.status === 200) {
+          this.$message.success('已添加');
+          this.form = { uid: null, permissionKey: null, expiresAt: null };
+          await this.reload();
+        } else {
+          this.$message.error(res.data && res.data.message || '添加失败');
+        }
+      } catch (e) {
+        this.$message.error(e.message || '添加失败');
+      } finally {
+        this.granting = false;
+      }
+    },
+    async revoke(row) {
+      try {
+        await ElMessageBox.confirm(`确认移除 ${row.name} 的 ${row.permissionKey} 权限？`, '提示', { type: 'warning' });
+      } catch (_) { return; }
+      try {
+        const res = await axios.post('/api/auth/revokeUserPermission', { id: row.id });
+        if (res.status === 200) { this.$message.success('已移除'); await this.reload(); }
+        else this.$message.error(res.data && res.data.message || '移除失败');
+      } catch (e) {
+        this.$message.error(e.message || '移除失败');
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.box-card { margin: 10px; }
+.card-header { display: flex; justify-content: space-between; align-items: center; }
+.rlink { color: #409eff; text-decoration: none; }
+</style>

--- a/web/src/components/problem/caseManage.vue
+++ b/web/src/components/problem/caseManage.vue
@@ -336,15 +336,14 @@ export default {
     }
   },
   mounted() {
-    if (this.$store.state.gid < 2) {
-      this.$router.push(`/problem/${this.$route.params.pid}`);
-      return;
-    }
     this.pid = this.$route.params.pid;
     axios.post('/api/problem/getProblemAuth', {
       pid: this.pid,
     }).then(res => {
       this.auth = res.data.data;
+      if (!this.auth.manage) {
+        this.$router.push(`/problem/${this.pid}`);
+      }
     });
     this.all(1);
   }

--- a/web/src/components/problem/problemEdit.vue
+++ b/web/src/components/problem/problemEdit.vue
@@ -92,17 +92,21 @@
         </div>
       </el-card>
     </el-col>
+    <el-col :span="24" v-if="auth.manage && problemInfo.pid">
+      <CollaboratorPanel resource-type="problem" :resource-id="problemInfo.pid" :visible="auth.manage" />
+    </el-col>
   </el-row>
 </template>
 
 <script>
 import axios from 'axios';
+import CollaboratorPanel from '@/components/permission/CollaboratorPanel.vue';
 
 export default {
   name: "problemEdit",
+  components: { CollaboratorPanel },
   data() {
     return {
-      gid: 1,
       problemInfo: [],
       newTag: '',
       avalangList: [],
@@ -215,15 +219,16 @@ export default {
     },
   },
   mounted() {
-    if (this.$store.state.gid < 2) {
-      this.$router.push(`/problem/${this.$route.params.pid}`);
-      return;
-    }
+    // Server-side problemAuth.manage is the final word; render the page and
+    // disable the save button via auth.manage when the user can only view.
     this.pid = this.$route.params.pid;
     axios.post('/api/problem/getProblemAuth', {
       pid: this.pid,
     }).then(res => {
       this.auth = res.data.data;
+      if (!this.auth.manage && !this.auth.view) {
+        this.$router.push(`/problem/${this.pid}`);
+      }
     });
     this.all();
   }

--- a/web/src/components/problem/problemList.vue
+++ b/web/src/components/problem/problemList.vue
@@ -7,7 +7,7 @@
           <el-pagination @current-change="handleCurrentChange" :current-page="currentPage" :page-size="20"
             layout="total, prev, pager, next" :total="total"></el-pagination>
           <el-button-group>
-            <el-popconfirm v-if="this.gid >= 2" confirm-button-text="确认" cancel-button-text="取消" title="确认添加题目?"
+            <el-popconfirm v-if="$can('problem.create')" confirm-button-text="确认" cancel-button-text="取消" title="确认添加题目?"
               @confirm="addProblem">
               <template #reference>
                 <el-button type="success">
@@ -136,7 +136,6 @@ export default {
     return {
       problemList: [],
       total: 0,
-      gid: 1,
       pid: '',
       currentPage: 1,
       finished: false,
@@ -292,7 +291,6 @@ export default {
         this.$message.error('获取出题人失败' + res.data.message);
       }
     });
-    this.gid = this.$store.state.gid;
     let query = this.$route.query;
     if (query.name) this.filter.name = query.name;
     if (query.level) this.filter.level = parseInt(query.level);

--- a/web/src/components/problem/problemStat.vue
+++ b/web/src/components/problem/problemStat.vue
@@ -15,7 +15,7 @@
         <template #header>
           <div class="card-header">
             题解
-            <el-button-group v-if="this.$store.state.gid > 1">
+            <el-button-group v-if="$can('problem.edit.any')">
               <el-button type="success" :disabled="!bindMark.length" @click="bindPaste2Problem">
                 <el-icon class="el-icon--left">
                   <Plus />
@@ -47,7 +47,7 @@
             </template>
           </el-table-column>
           <el-table-column prop="time" label="更新时间" min-width="20%" />
-          <el-table-column v-if="this.$store.state.gid > 1" label="操作" min-width="15%">
+          <el-table-column v-if="$can('problem.edit.any')" label="操作" min-width="15%">
             <template #default="scope">
               <el-popconfirm confirm-button-text="确认" cancel-button-text="取消" title="确认解绑?"
                 @confirm="unbindSol(scope.row.id)">

--- a/web/src/components/problem/problemView.vue
+++ b/web/src/components/problem/problemView.vue
@@ -96,7 +96,7 @@
             </el-icon>
             数据统计
           </el-button>
-          <el-button v-if="this.gid > 1" type="danger" @click="this.$router.push('/problem/edit/' + problemInfo.pid)">
+          <el-button v-if="canManage" type="danger" @click="this.$router.push('/problem/edit/' + problemInfo.pid)">
             <el-icon class="el-icon--left">
               <Operation />
             </el-icon>
@@ -114,10 +114,17 @@ import monacoEditor from '@/components/monacoEditor.vue'
 
 export default {
   name: "problemView",
+  computed: {
+    canManage() {
+      return this.problemInfo && (
+        this.problemInfo.publisherUid === this.$store.state.uid
+        || this.$can('problem.edit.any')
+      );
+    },
+  },
   data() {
     return {
       pid: 0,
-      gid: 1,
       submitLang: null,
       langList: [],
       problemInfo: {},
@@ -191,7 +198,6 @@ export default {
   },
   async mounted() {
     this.pid = this.$route.params.pid;
-    this.gid = this.$store.state.gid;
     await axios.post('/api/problem/getProblemInfo', { pid: this.pid }).then(res => {
       if (res.status === 200) {
         this.problemInfo = res.data.data

--- a/web/src/components/rabbit/cuteRabbit.vue
+++ b/web/src/components/rabbit/cuteRabbit.vue
@@ -131,7 +131,7 @@ export default {
       style['textAlign'] = 'center';
       if (columnIndex === 2) {
         style['font-weight'] = 500;
-        style['color'] = getNameColor(row.gid, row.clickCnt);
+        style['color'] = getNameColor(row.isStaff, row.clickCnt);
         if (style['color'] === '#8e44ad')
           style['font-weight'] = 900;
       }

--- a/web/src/components/rabbit/cuteRankList.vue
+++ b/web/src/components/rabbit/cuteRankList.vue
@@ -71,7 +71,7 @@ export default {
         style['textAlign'] = 'center';
       if (columnIndex === 1) {
         style['font-weight'] = 500;
-        style['color'] = getNameColor(row.gid, row.clickCnt);
+        style['color'] = getNameColor(row.isStaff, row.clickCnt);
         if (style['color'] === '#8e44ad')
           style['font-weight'] = 900;
       }

--- a/web/src/components/submission/submissionList.vue
+++ b/web/src/components/submission/submissionList.vue
@@ -47,7 +47,7 @@
             <el-input v-model="filter.cid" type="text" placeholder="比赛id" style="width: 80px;" @keyup.enter="all" />
           </el-form-item>
         </el-form>
-        <span v-if="this.$store.state.gid >= 2" style="font-size: 14px; font-weight: 600; margin:0 20px 0 10px;">
+        <span v-if="$can('contest.submission.view.cross')" style="font-size: 14px; font-weight: 600; margin:0 20px 0 10px;">
           比赛提交：
           <el-switch v-model="queryAll" class="mb-2" active-text="显示" inactive-text="隐藏" @change="all" />
         </span>
@@ -194,7 +194,7 @@ export default {
       if (this.filter.score !== null) param.score = this.filter.score;
       if (this.filter.res !== null) param.res = this.filter.res;
       if (this.filter.lang !== null) param.lang = this.filter.lang;
-      if (this.queryAll && this.$store.state.gid > 1) param.queryAll = true;
+      if (this.queryAll && this.$can('contest.submission.view.cross')) param.queryAll = true;
       if (this.currentPage > 1)
         param.pageId = this.currentPage;
       let nurl = qs.stringify(param);
@@ -261,7 +261,7 @@ export default {
     if (query.pid) this.filter.pid = query.pid;
     if (query.cid) this.filter.cid = query.cid;
     if (query.lang) this.filter.lang = parseInt(query.lang);
-    if (query.queryAll && this.$store.state.gid > 1) this.queryAll = true;
+    if (query.queryAll && this.$can('contest.submission.view.cross')) this.queryAll = true;
     if (query.pageId) this.currentPage = parseInt(query.pageId);
     this.all();
   }

--- a/web/src/components/submission/submissionView.vue
+++ b/web/src/components/submission/submissionView.vue
@@ -60,7 +60,7 @@
           <div class=" card-header">
             代码
             <el-button-group>
-              <el-popconfirm v-if="gid > 2" confirm-button-text="确认" cancel-button-text="取消" title="确认取消成绩?"
+              <el-popconfirm v-if="$can('submission.rejudge')" confirm-button-text="确认" cancel-button-text="取消" title="确认取消成绩?"
                 @confirm="cancelSubmission">
                 <template #reference>
                   <el-button type="warning">
@@ -71,7 +71,7 @@
                   </el-button>
                 </template>
               </el-popconfirm>
-              <el-popconfirm v-if="gid > 1" confirm-button-text="确认" cancel-button-text="取消" title="确认重新测评?"
+              <el-popconfirm v-if="$can('submission.rejudge')" confirm-button-text="确认" cancel-button-text="取消" title="确认重新测评?"
                 @confirm="reJudge">
                 <template #reference>
                   <el-button type="danger">
@@ -140,7 +140,6 @@ export default {
   name: "problemView",
   data() {
     return {
-      gid: 1,
       table: [],
       submissionInfo: [],
       code: '',
@@ -223,7 +222,6 @@ export default {
     this.sid = this.$route.params.sid;
     if (this.$route.query.isContest) this.isContest = true;
     document.title = "提交记录";
-    this.gid = this.$store.state.gid;
     await this.all();
   },
   unmounted() {

--- a/web/src/components/user/userInfo.vue
+++ b/web/src/components/user/userInfo.vue
@@ -14,9 +14,11 @@
           <span class="subtitle">邮箱</span>
           <span style="float: right;">{{ info.email }}</span>
         </div>
-        <div class="infos">
+        <div class="infos" v-if="roleLabels.length">
           <span class="subtitle">用户类型</span>
-          <span style="float: right;">{{ group[info.gid] }}</span>
+          <span style="float: right;">
+            <el-tag v-for="r in roleLabels" :key="r" size="small" style="margin-left: 4px;">{{ r }}</el-tag>
+          </span>
         </div>
         <div class="infos">
           <span class="subtitle">注册时间</span>
@@ -53,10 +55,26 @@ export default {
       info: {},
       newMotto: '/',
       avatarAddress: '',
-      group: ['', '普通用户', '管理员', '超级管理员'],
+      // Friendly labels for builtin role keys; unknown keys fall through unchanged.
+      roleLabel: {
+        user: '普通用户',
+        problem_setter: '出题人',
+        contest_manager: '比赛管理员',
+        judge_admin: '判题管理员',
+        moderator: '管理员',
+        super_admin: '超级管理员',
+      },
       date: [],
       clickCnt: [],
     }
+  },
+  computed: {
+    roleLabels() {
+      const roles = (this.info && this.info.roles) || [];
+      return roles
+        .filter((k) => k !== 'user') // skip the default empty-permission role
+        .map((k) => this.roleLabel[k] || k);
+    },
   },
   methods: {
     all() {

--- a/web/src/router/router.js
+++ b/web/src/router/router.js
@@ -32,12 +32,9 @@ import permissionCenter from "@/components/admin/permissionCenter"
 import { refreshUserInfo } from '@/assets/common'
 import store from '@/sto/store';
 
-const per = [];
-
-per["/admin/usermanage"] = 3;
-
-// permission-based gates: route -> [required permission keys, any-of]
+// Permission-gated routes: route -> [required permission keys, any-of].
 const perPermissions = {
+  '/admin/usermanage': ['user.list', 'user.edit', 'user.ban'],
   '/admin/permissions': ['user.role.assign', 'user.permission.grant'],
 };
 
@@ -215,7 +212,6 @@ router.beforeEach(async (to, from, next) => {
         await refreshUserInfo();
     }
     if (store.state.uid) {
-        if (per[to.path] && store.state.gid < per[to.path]) return;
         const need = perPermissions[to.path];
         if (need && !need.some((k) => (store.state.permissions || []).indexOf(k) >= 0)) return;
         next();

--- a/web/src/sto/store.js
+++ b/web/src/sto/store.js
@@ -4,7 +4,6 @@ export default createStore({
     state: {
         uid: 0,
         name: "/",
-        gid: 0,
         ip: '',
         path: '',
         avatar: '',


### PR DESCRIPTION
## Summary

完成 `gid` → 权限系统的最后一公里：服务端、前端、数据库三处全部去 gid，启动时自动 drop 列。

### 服务端

- 移除 `requireRole` helper；所有调用点改为 `requirePermission(<key>)` 或 handler 内 owner-or-permission
- `req.session.gid` 不再设置，`getUserInfo` 不再返回 `gid`
- `problemAuth` / `canManageContest` / `canManagePlayers` 三个共享 helper 把 owner-or-scoped-permission 模式集中
- 提交可见性切换到 `submission.view.any` / `contest.submission.view.cross` / `paste.edit.any`
- `/api/admin/*` 全局拦截移除（每个 handler 自鉴权）
- `admin.getUserInfoList` 暴露 `roles[]` 数组 + 支持按 `roleKey` 筛选；`updateUserInfo` 不再接受 gid
- `rabbit.all/getRankInfo` 改为查 `user_roles` 派生 `isStaff` 标志（替代 gid 派生的"管理员紫色名字"）
- **`sync.js` 启动时自动 `ALTER TABLE userInfo DROP COLUMN gid`**（`DISABLE_DROP_GID=1` 可临时跳过）

### 前端

- `store.state.gid` 移除；`refreshUserInfo` 不再读它
- 所有 v-if / :disabled / 路由守卫切换到 `$can` / `$canAny`
- `getNameColor(gid, cnt)` → `getNameColor(isStaff, cnt)`
- `userManage.vue` 重写：gid 列 / 筛选 / 编辑全部换成**角色标签 + 按角色筛选**，并提供深链到 `/admin/permissions` 做细粒度调整
- `userInfo.vue` 用户类型显示由 gid 数值 → 角色 label 标签
- `permissionCenter` 删掉「主 gid」描述项与 legacy_gid 列
- 重新加回 `CollaboratorPanel` + 题目/比赛页集成（之前在 PR #10 一起被 revert）

### 测试 + 文档

- [server/auth/test.js](server/auth/test.js)：71 项断言对真实 DB 全部通过；覆盖 schema 同步（包含 drop gid）、policy 三集合 / scoped / deny / expires / cache、`/api/auth/*` 全套、资源 owner 授权路径、`requirePermission` 中间件
- [server/auth/MIGRATION.md](server/auth/MIGRATION.md)：上云迁移指南，含 soak 窗口 (`DISABLE_DROP_GID=1`) 与回滚手册

## Test plan

- [ ] `node server/auth/test.js` → 71 passed
- [ ] 启动服务，日志看到 `[auth] dropping legacy userInfo.gid column`（或之前已删，无此日志）
- [ ] `DESCRIBE userInfo;` 已无 gid 列
- [ ] 升级前 gid=2 用户登录后能正常出题 / 办赛 / 重测
- [ ] 升级前 gid=3 用户能进入 `/admin/permissions`、能看到「用户管理」入口
- [ ] 普通用户能编辑自己的题目（之前需要 gid≥2）
- [ ] 题目页 / 比赛页协作者面板可用

## Migration

详见 [MIGRATION.md](server/auth/MIGRATION.md)。简版：

```bash
# 1. 备份
mysqldump <db> > backup.sql

# 2. 第一次部署，保留 gid 列做观察
DISABLE_DROP_GID=1 pm2 restart nywoj

# 3. 1~2 天后正式 drop
unset DISABLE_DROP_GID && pm2 restart nywoj
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)